### PR TITLE
feat: add disabled variant support to Button component

### DIFF
--- a/src/components/Button/Button.css
+++ b/src/components/Button/Button.css
@@ -80,3 +80,21 @@
   border-color: #dc2626;
   box-shadow: 0 4px 16px rgba(239, 68, 68, 0.38);
 }
+
+
+/* ── Disabled Variant ── */
+.uiverse-btn--disabled {
+  background-color: #9ca3af;
+  color: #ffffff;
+  border-color: #9ca3af;
+  opacity: 0.7;
+  cursor: not-allowed;
+  pointer-events: auto;
+  box-shadow: none;
+}
+
+.uiverse-btn--disabled:hover,
+.uiverse-btn--disabled:active {
+  transform: none;
+  box-shadow: none;
+}

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -2,7 +2,7 @@
 //
 // Props:
 //   text     (string)  – Label displayed inside the button
-//   variant  (string)  – "primary" | "secondary" | "danger"
+//   variant  (string)  – "primary" | "secondary" | "danger" | "disabled"
 //   size     (string)  – "sm" | "md" (default) | "lg"
 //   onClick  (func)    – Optional click handler
 //

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -83,6 +83,7 @@ function Components() {
                 <Button text="Primary" variant="primary" />
                 <Button text="Secondary" variant="secondary" />
                 <Button text="Danger" variant="danger" />
+                <Button text="Disabled" variant="disabled" />
               </div>
             </div>
 
@@ -110,6 +111,7 @@ function Components() {
               <pre>{`<Button text="Primary"   variant="primary" />
 <Button text="Secondary" variant="secondary" />
 <Button text="Danger"    variant="danger" />
+<Button text="Disabled"  variant="disabled" />
 
 {/* Sizes */}
 <Button text="Small"  variant="primary" size="sm" />


### PR DESCRIPTION
## Description

Added a new `disabled` variant to the reusable Button component.

### Changes Made

* Added `disabled` button variant styling
* Disabled hover and active interactions for disabled buttons
* Added disabled button preview in Components showcase
* Updated button examples and documentation

Fixes #2

## Screenshot for reference
<img width="953" height="410" alt="image" src="https://github.com/user-attachments/assets/c45057ca-f514-4891-92a3-8f83f02ea9a7" />
