### PR TITLE
fix: resolve SPA routing 404 issue on Vercel deployment (#26)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
## 📌 Related Issue

Closes #26

---

## 🛠️ What I Changed

* Added a `vercel.json` configuration file
* Configured rewrite rules to redirect all routes to `index.html`
* Fixed 404 errors occurring on page refresh or direct URL access in the deployed SPA

### Added Configuration

```json
{
  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
}
```

---

## ✅ Issue Resolved

Previously, routes like `/about` or `/contact` worked only through internal navigation but returned a **404 Not Found** error when refreshed or directly accessed.

This PR ensures proper client-side routing support for the SPA deployed on Vercel.

---

## 🧪 Tested

* Internal navigation between pages
* Browser refresh on nested routes
* Direct URL access for SPA routes

All routes now load successfully without 404 errors.

---

## 🚀 GSSoC 2026 Contribution

This contribution is made under **GirlScript Summer of Code 2026 (GSSoC 2026)**.

Kindly review this PR.
cc: @ayushkashyap402
