### PR TITLE
docs: fix README dependency inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Every component is:
 | 🧑‍💻 Beginner Friendly | Every file has comments explaining what and why |
 | 🤝 Contributor Ready | Clear folder structure, easy to add new components |
 | 🏆 GSSoC Ready | Structured for open-source programs like GSSoC |
-| 📦 Zero Extra Deps | Only React + React Router. No bloat |
+| 📦 Minimal Dependencies | Uses React, React Router, and react-icons while keeping the project lightweight |
 | 🎨 Plain CSS | No Tailwind — so contributors learn real CSS |
 
 ---
@@ -297,6 +297,7 @@ Looking for something to build? Here are some ideas:
 | [Vite](https://vitejs.dev) | 5 | Dev server + bundler |
 | [React Router](https://reactrouter.com) | 6 | Client-side routing |
 | Plain CSS | — | Component styling |
+| [React Icons](https://react-icons.github.io/react-icons/) | 5 | Lightweight icon library for React components |
 
 ---
 


### PR DESCRIPTION
## Description

This PR fixes the README dependency inconsistency mentioned in issue #27.

The README previously stated that UIverse has zero extra dependencies and uses only React + React Router. However, package.json includes react-icons as an additional dependency.

## Changes Made

- Replaced “Zero Extra Deps” with “Minimal Dependencies”
- Updated the dependency description to include react-icons
- Added React Icons to the Tech Stack section
- Kept the README beginner-friendly and consistent with package.json

## Related Issue

Closes #27

## Checklist

- [x] README updated
- [x] Documentation-only change
- [x] No extra dependency added
- [x] README now matches package.json