### PR TITLE
feat: Add interactive Color Wall feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,8 @@ import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home.jsx'
 import Components from './pages/Components.jsx'
 
+import ColorWall from './pages/ColorWall.jsx';
+
 function App() {
   return (
     <Routes>
@@ -14,6 +16,9 @@ function App() {
 
       {/* Components showcase page */}
       <Route path="/components" element={<Components />} />
+
+      {/* Color Wall */}
+      <Route path="/color-wall" element={<ColorWall />} />
     </Routes>
   )
 }

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -113,6 +113,12 @@ function Navbar() {
           Components
         </Link>
 
+        {/* color wall page */}
+        <Link to="/color-wall" onClick={closeMenu}
+          className={`navbar-link ${location.pathname === '/color-wall' ? 'active' : ''}`}>
+          Color Wall
+        </Link>
+
         {/* GitHub */}
         <a
           href="https://github.com/ayushkashyap402/UIverse"
@@ -130,6 +136,8 @@ function Navbar() {
         >
           {dark ? <SunIcon /> : <MoonIcon />}
         </button>
+
+
 
       </div>
 

--- a/src/pages/ColorWall.css
+++ b/src/pages/ColorWall.css
@@ -1,4 +1,4 @@
-/* use var(--bg) so it automatically flips to black in dark mode! */
+/* 1. Page Layout & Headers */
 .color-wall-page {
   min-height: 100vh;
   background-color: var(--bg);
@@ -32,104 +32,7 @@
   font-size: 1.5rem;
 }
 
-/* ── CSS Grid makes the cards responsive automatically ── */
-.palette-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 2rem;
-}
-
-.palette-card {
-  background-color: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  overflow: hidden; /* Keeps the color swatches inside the rounded corners */
-  box-shadow: var(--shadow-sm);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-/* Adds a nice hover lift effect */
-.palette-card:hover {
-  transform: translateY(-4px);
-  box-shadow: var(--shadow-md);
-}
-
-/* ── Flexbox trick for the color bars ── */
-.palette-swatches {
-  display: flex;
-  height: 120px;
-}
-
-.swatch {
-  flex: 1; /* Makes all swatches share the width equally */
-  transition: flex 0.2s ease; /* Animates the width change */
-  cursor: pointer;
-}
-
-.swatch:hover {
-  flex: 1.5; /* Makes the hovered color expand slightly! */
-}
-
-.palette-info {
-  padding: 1.2rem;
-}
-
-.palette-info h3 {
-  margin-bottom: 0.8rem;
-  color: var(--text);
-  font-size: 1.1rem;
-}
-
-.hex-codes {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.hex-codes span {
-  font-size: 0.75rem;
-  color: var(--text-2);
-  background-color: var(--bg-alt);
-  padding: 0.3rem 0.6rem;
-  border-radius: 6px;
-  font-family: monospace;
-}
-
-/* Make it obvious that the hex code text is clickable */
-.clickable-hex {
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-}
-
-.clickable-hex:hover {
-  background-color: var(--accent);
-  color: var(--brand);
-}
-
-/* The floating notification */
-.copy-toast {
-  position: fixed;
-  bottom: 2rem;
-  left: 50%;
-  transform: translateX(-50%);
-  background-color: var(--surface);
-  color: var(--text);
-  padding: 0.75rem 1.5rem;
-  border-radius: 50px;
-  box-shadow: var(--shadow-md);
-  border: 1px solid var(--border);
-  font-size: 0.9rem;
-  z-index: 1000;
-  animation: slideUp 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-}
-
-@keyframes slideUp {
-  from { opacity: 0; transform: translate(-50%, 20px); }
-  to { opacity: 1; transform: translate(-50%, 0); }
-}
-
-
-/* ── Tab Navigation ── */
+/* 2. Tab Navigation */
 .wall-tabs {
   display: flex;
   gap: 1rem;
@@ -160,43 +63,102 @@
   border-color: var(--brand);
 }
 
-/* ── Palette Info Header (Title & Heart) ── */
-.palette-info-header {
+/* 3. Contrast Checker Section */
+.contrast-section {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-top: 5rem;
+  margin-bottom: 4rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.contrast-section h2 {
+  color: var(--text);
+  margin-bottom: 1.5rem;
+  font-size: 1.4rem;
+}
+
+.contrast-container {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.contrast-controls {
+  flex: 1;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.control-group label {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--text-2);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.contrast-score {
+  margin-top: auto;
+  padding: 1rem;
+  background-color: var(--bg);
+  border-radius: 8px;
+  border: 1px solid var(--border);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 0.8rem;
 }
 
-.palette-info-header h3 {
-  margin-bottom: 0; /* Override the old margin */
+.score-number {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--text);
 }
 
-.favorite-btn {
-  background: none;
-  border: none;
-  font-size: 1.2rem;
-  cursor: pointer;
-  padding: 0.2rem;
-  border-radius: 50%;
-  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+.score-badge {
+  padding: 0.4rem 0.8rem;
+  border-radius: 50px;
+  font-size: 0.85rem;
+  font-weight: 700;
 }
 
-.favorite-btn:hover {
-  transform: scale(1.2);
+.score-badge.pass {
+  background-color: #dcfce7;
+  color: #166534;
 }
 
-.empty-state {
-  grid-column: 1 / -1; /* Makes it span the whole grid */
-  text-align: center;
-  color: var(--muted);
-  padding: 3rem;
-  background-color: var(--surface);
+.score-badge.fail {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.contrast-preview {
+  flex: 1.5;
+  min-width: 300px;
+  padding: 2.5rem;
   border-radius: 12px;
-  border: 1px dashed var(--border);
+  border: 1px solid var(--border);
+  transition: background-color 0.3s ease, color 0.3s ease; 
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
-/* ── Builder Section Styling ── */
+.contrast-preview h3 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+}
+
+.contrast-preview p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+/* 4. Builder Section */
 .builder-section {
   background-color: var(--surface);
   border: 1px solid var(--border);
@@ -272,25 +234,6 @@
   border: 1px solid var(--border-2);
 }
 
-.color-picker-input {
-  -webkit-appearance: none;
-  border: none;
-  width: 100%;
-  height: 50px;
-  border-radius: 8px;
-  cursor: pointer;
-  background: transparent;
-}
-
-.color-picker-input::-webkit-color-swatch-wrapper {
-  padding: 0;
-}
-
-.color-picker-input::-webkit-color-swatch {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-}
-
 .picker-hex-label {
   font-family: monospace;
   font-size: 0.85rem;
@@ -298,53 +241,10 @@
   font-weight: 600;
 }
 
-/* Custom Tag Badge */
-.custom-badge {
-  font-size: 0.7rem;
-  background-color: var(--accent-2);
-  color: var(--brand-2);
-  padding: 0.15rem 0.5rem;
-  border-radius: 4px;
-  margin-left: 0.5rem;
-  vertical-align: middle;
-}
-
-/* ── Phase 4: Contrast Checker Styling ── */
-.contrast-section {
-  background-color: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 2rem;
-  margin-bottom: 4rem;
-  box-shadow: var(--shadow-sm);
-}
-
-.contrast-section h2 {
-  color: var(--text);
-  margin-bottom: 1.5rem;
-  font-size: 1.4rem;
-}
-
-.contrast-container {
-  display: flex;
-  gap: 2rem;
-  flex-wrap: wrap;
-}
-
-.contrast-controls {
-  flex: 1;
-  min-width: 280px;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.control-group label {
-  display: block;
-  font-size: 0.9rem;
-  color: var(--text-2);
-  margin-bottom: 0.5rem;
-  font-weight: 600;
+/* Shared Native Color Picker Customization */
+.picker-wrapper,
+.picker-container {
+  /* Used in both Builder and Contrast Checker */
 }
 
 .picker-wrapper {
@@ -357,18 +257,34 @@
   border: 1px solid var(--border-2);
 }
 
-/* Customizing the native color picker input */
-.picker-wrapper input[type="color"] {
+.picker-wrapper span {
+  font-family: monospace;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.picker-wrapper input[type="color"],
+.color-picker-input {
   -webkit-appearance: none;
   border: none;
-  width: 35px;
-  height: 35px;
-  border-radius: 50%;
   cursor: pointer;
   background: transparent;
 }
 
-.picker-wrapper input[type="color"]::-webkit-color-swatch-wrapper {
+.picker-wrapper input[type="color"] {
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+}
+
+.color-picker-input {
+  width: 100%;
+  height: 50px;
+  border-radius: 8px;
+}
+
+.picker-wrapper input[type="color"]::-webkit-color-swatch-wrapper,
+.color-picker-input::-webkit-color-swatch-wrapper {
   padding: 0;
 }
 
@@ -377,69 +293,166 @@
   border-radius: 50%;
 }
 
-.picker-wrapper span {
-  font-family: monospace;
-  color: var(--text);
-  font-weight: 500;
+.color-picker-input::-webkit-color-swatch {
+  border: 1px solid var(--border);
+  border-radius: 8px;
 }
 
-.contrast-score {
-  margin-top: auto;
-  padding: 1rem;
-  background-color: var(--bg);
-  border-radius: 8px;
+/* 5. Palette Grid & Cards */
+.palette-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.palette-card {
+  background-color: var(--surface);
   border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.palette-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+.palette-swatches {
+  display: flex;
+  height: 120px;
+}
+
+.swatch {
+  flex: 1;
+  transition: flex 0.2s ease;
+  cursor: pointer;
+}
+
+.swatch:hover {
+  flex: 1.5;
+}
+
+.palette-info {
+  padding: 1.2rem;
+}
+
+.palette-info-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 0.8rem;
 }
 
-.score-number {
-  font-size: 1.5rem;
-  font-weight: 800;
+.palette-info-header h3 {
+  margin-bottom: 0;
   color: var(--text);
-}
-
-.score-badge {
-  padding: 0.4rem 0.8rem;
-  border-radius: 50px;
-  font-size: 0.85rem;
-  font-weight: 700;
-}
-
-.score-badge.pass {
-  background-color: #dcfce7;
-  color: #166534;
-}
-
-.score-badge.fail {
-  background-color: #fee2e2;
-  color: #991b1b;
-}
-
-.contrast-preview {
-  flex: 1.5;
-  min-width: 300px;
-  padding: 2.5rem;
-  border-radius: 12px;
-  border: 1px solid var(--border);
-  /* The transition makes it smoothly fade when the user changes the color picker! */
-  transition: background-color 0.3s ease, color 0.3s ease; 
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-}
-
-.contrast-preview h3 {
-  font-size: 1.8rem;
-  margin-bottom: 1rem;
-}
-
-.contrast-preview p {
   font-size: 1.1rem;
-  line-height: 1.6;
 }
 
-.contrast-section{
-    margin-top: 5rem;
+.hex-codes {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
+
+.hex-codes span {
+  font-size: 0.75rem;
+  color: var(--text-2);
+  background-color: var(--bg-alt);
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  font-family: monospace;
+}
+
+.clickable-hex {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.clickable-hex:hover {
+  background-color: var(--accent);
+  color: var(--brand);
+}
+
+.palette-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.favorite-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0.2rem;
+  border-radius: 50%;
+  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.favorite-btn:hover {
+  transform: scale(1.2);
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.3rem;
+  border-radius: 50%;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  opacity: 0.6;
+}
+
+.delete-btn:hover {
+  opacity: 1;
+  background-color: #fee2e2;
+  transform: scale(1.1);
+}
+
+.custom-badge {
+  font-size: 0.7rem;
+  background-color: var(--accent-2);
+  color: var(--brand-2);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+/* 6. UI Utilities (Empty States, Toasts) */
+.empty-state {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--muted);
+  padding: 3rem;
+  background-color: var(--surface);
+  border-radius: 12px;
+  border: 1px dashed var(--border);
+}
+
+.copy-toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--surface);
+  color: var(--text);
+  padding: 0.75rem 1.5rem;
+  border-radius: 50px;
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border);
+  font-size: 0.9rem;
+  z-index: 1000;
+  animation: slideUp 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translate(-50%, 20px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+```

--- a/src/pages/ColorWall.css
+++ b/src/pages/ColorWall.css
@@ -308,3 +308,138 @@
   margin-left: 0.5rem;
   vertical-align: middle;
 }
+
+/* ── Phase 4: Contrast Checker Styling ── */
+.contrast-section {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 4rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.contrast-section h2 {
+  color: var(--text);
+  margin-bottom: 1.5rem;
+  font-size: 1.4rem;
+}
+
+.contrast-container {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.contrast-controls {
+  flex: 1;
+  min-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.control-group label {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--text-2);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.picker-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background-color: var(--bg-alt);
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: 1px solid var(--border-2);
+}
+
+/* Customizing the native color picker input */
+.picker-wrapper input[type="color"] {
+  -webkit-appearance: none;
+  border: none;
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+  cursor: pointer;
+  background: transparent;
+}
+
+.picker-wrapper input[type="color"]::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.picker-wrapper input[type="color"]::-webkit-color-swatch {
+  border: 1px solid var(--border);
+  border-radius: 50%;
+}
+
+.picker-wrapper span {
+  font-family: monospace;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.contrast-score {
+  margin-top: auto;
+  padding: 1rem;
+  background-color: var(--bg);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.score-number {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--text);
+}
+
+.score-badge {
+  padding: 0.4rem 0.8rem;
+  border-radius: 50px;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.score-badge.pass {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.score-badge.fail {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.contrast-preview {
+  flex: 1.5;
+  min-width: 300px;
+  padding: 2.5rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  /* The transition makes it smoothly fade when the user changes the color picker! */
+  transition: background-color 0.3s ease, color 0.3s ease; 
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.contrast-preview h3 {
+  font-size: 1.8rem;
+  margin-bottom: 1rem;
+}
+
+.contrast-preview p {
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.contrast-section{
+    margin-top: 5rem;
+}

--- a/src/pages/ColorWall.css
+++ b/src/pages/ColorWall.css
@@ -1,0 +1,310 @@
+/* use var(--bg) so it automatically flips to black in dark mode! */
+.color-wall-page {
+  min-height: 100vh;
+  background-color: var(--bg);
+}
+
+.color-wall-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3rem 2rem;
+}
+
+.color-wall-header {
+  text-align: center;
+  margin-bottom: 4rem;
+}
+
+.color-wall-header h1 {
+  font-size: 2.5rem;
+  color: var(--text);
+  margin-bottom: 0.5rem;
+}
+
+.color-wall-header p {
+  color: var(--muted);
+  font-size: 1.1rem;
+}
+
+.color-wall-section h2 {
+  color: var(--text);
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+}
+
+/* ── CSS Grid makes the cards responsive automatically ── */
+.palette-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.palette-card {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden; /* Keeps the color swatches inside the rounded corners */
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Adds a nice hover lift effect */
+.palette-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+/* ── Flexbox trick for the color bars ── */
+.palette-swatches {
+  display: flex;
+  height: 120px;
+}
+
+.swatch {
+  flex: 1; /* Makes all swatches share the width equally */
+  transition: flex 0.2s ease; /* Animates the width change */
+  cursor: pointer;
+}
+
+.swatch:hover {
+  flex: 1.5; /* Makes the hovered color expand slightly! */
+}
+
+.palette-info {
+  padding: 1.2rem;
+}
+
+.palette-info h3 {
+  margin-bottom: 0.8rem;
+  color: var(--text);
+  font-size: 1.1rem;
+}
+
+.hex-codes {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.hex-codes span {
+  font-size: 0.75rem;
+  color: var(--text-2);
+  background-color: var(--bg-alt);
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  font-family: monospace;
+}
+
+/* Make it obvious that the hex code text is clickable */
+.clickable-hex {
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.clickable-hex:hover {
+  background-color: var(--accent);
+  color: var(--brand);
+}
+
+/* The floating notification */
+.copy-toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: var(--surface);
+  color: var(--text);
+  padding: 0.75rem 1.5rem;
+  border-radius: 50px;
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border);
+  font-size: 0.9rem;
+  z-index: 1000;
+  animation: slideUp 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+@keyframes slideUp {
+  from { opacity: 0; transform: translate(-50%, 20px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+
+/* ── Tab Navigation ── */
+.wall-tabs {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  justify-content: center;
+}
+
+.wall-tab {
+  background-color: transparent;
+  color: var(--text-2);
+  border: 1px solid var(--border);
+  padding: 0.5rem 1.25rem;
+  border-radius: 50px;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.wall-tab:hover {
+  background-color: var(--surface);
+  color: var(--text);
+}
+
+.wall-tab.active {
+  background-color: var(--brand);
+  color: white;
+  border-color: var(--brand);
+}
+
+/* ── Palette Info Header (Title & Heart) ── */
+.palette-info-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.8rem;
+}
+
+.palette-info-header h3 {
+  margin-bottom: 0; /* Override the old margin */
+}
+
+.favorite-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0.2rem;
+  border-radius: 50%;
+  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+}
+
+.favorite-btn:hover {
+  transform: scale(1.2);
+}
+
+.empty-state {
+  grid-column: 1 / -1; /* Makes it span the whole grid */
+  text-align: center;
+  color: var(--muted);
+  padding: 3rem;
+  background-color: var(--surface);
+  border-radius: 12px;
+  border: 1px dashed var(--border);
+}
+
+/* ── Builder Section Styling ── */
+.builder-section {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 4rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.builder-section h2 {
+  color: var(--text);
+  margin-bottom: 1.5rem;
+  font-size: 1.4rem;
+}
+
+.builder-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.builder-inputs {
+  display: flex;
+  gap: 1rem;
+}
+
+.builder-text-input {
+  flex: 1;
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  font-size: 1rem;
+}
+
+.builder-text-input:focus {
+  border-color: var(--brand);
+}
+
+.builder-submit-btn {
+  background-color: var(--brand);
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.builder-submit-btn:hover {
+  background-color: var(--brand-dark);
+}
+
+.builder-pickers {
+  display: flex;
+  gap: 1.5rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.picker-container {
+  flex: 1;
+  min-width: 100px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: var(--bg-alt);
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--border-2);
+}
+
+.color-picker-input {
+  -webkit-appearance: none;
+  border: none;
+  width: 100%;
+  height: 50px;
+  border-radius: 8px;
+  cursor: pointer;
+  background: transparent;
+}
+
+.color-picker-input::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.color-picker-input::-webkit-color-swatch {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.picker-hex-label {
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: var(--text-2);
+  font-weight: 600;
+}
+
+/* Custom Tag Badge */
+.custom-badge {
+  font-size: 0.7rem;
+  background-color: var(--accent-2);
+  color: var(--brand-2);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}

--- a/src/pages/ColorWall.jsx
+++ b/src/pages/ColorWall.jsx
@@ -1,0 +1,210 @@
+import React, { useState, useEffect } from 'react';
+import Navbar from '../components/Navbar/Navbar.jsx';
+import './ColorWall.css';
+
+const defaultPresets = [
+  { name: 'Ocean Breeze', colors: ['#0f172a', '#0ea5e9', '#38bdf8', '#e0f2fe'] },
+  { name: 'Sunset Glow', colors: ['#4c0519', '#e11d48', '#fb923c', '#ffedd5'] },
+  { name: 'Forest Path', colors: ['#064e3b', '#10b981', '#6ee7b7', '#d1fae5'] },
+  { name: 'Purple Dream', colors: ['#3b0764', '#9333ea', '#d8b4fe', '#f3e8ff'] }
+];
+
+function ColorWall() {
+  const [copiedColor, setCopiedColor] = useState(null);
+  const [activeTab, setActiveTab] = useState('all');
+
+  // PHASE 3 STATE
+  // Initialize custom palettes from local storage
+  const [customPalettes, setCustomPalettes] = useState(() => {
+    const savedCustom = localStorage.getItem('uiverse-custom-palettes');
+    return savedCustom ? JSON.parse(savedCustom) : [];
+  });
+
+  // State for the builder inputs
+  const [customName, setCustomName] = useState('');
+  const [customColors, setCustomColors] = useState(['#ffffff', '#ffffff', '#ffffff', '#ffffff']);
+
+  // Combine default presets and user-created custom palettes into one master list
+  const allPalettes = [...customPalettes, ...defaultPresets];
+
+  // ── PHASE 2 STATE (Favorites) ──
+  const [favorites, setFavorites] = useState(() => {
+    const savedFavs = localStorage.getItem('uiverse-favorites');
+    return savedFavs ? JSON.parse(savedFavs) : [];
+  });
+
+  // Sync favorites to local storage
+  useEffect(() => {
+    localStorage.setItem('uiverse-favorites', JSON.stringify(favorites));
+  }, [favorites]);
+
+  // Sync custom palettes to local storage
+  useEffect(() => {
+    localStorage.setItem('uiverse-custom-palettes', JSON.stringify(customPalettes));
+  }, [customPalettes]);
+
+  const handleCopy = (color) => {
+    navigator.clipboard.writeText(color);
+    setCopiedColor(color);
+    setTimeout(() => setCopiedColor(null), 2000);
+  };
+
+  const toggleFavorite = (presetName) => {
+    if (favorites.includes(presetName)) {
+      setFavorites(favorites.filter(name => name !== presetName));
+    } else {
+      setFavorites([...favorites, presetName]);
+    }
+  };
+
+  // PHASE 3 FUNCTIONS 
+  // Handles updating a specific color slot (0 to 3) when a picker changes
+  const handleColorChange = (index, value) => {
+    const updatedColors = [...customColors];
+    updatedColors[index] = value;
+    setCustomColors(updatedColors);
+  };
+
+  // Saves the custom palette
+  const handleSaveCustomPalette = (e) => {
+    e.preventDefault(); // Prevents the form from reloading the page
+    if (!customName.trim()) return alert('Please enter a palette name!');
+
+    const newPalette = {
+      name: customName,
+      colors: [...customColors],
+      isCustom: true // Tagged so we can display a custom badge if we want
+    };
+
+    setCustomPalettes([newPalette, ...customPalettes]);
+    setCustomName(''); // Reset input field
+    setCustomColors(['#ffffff', '#ffffff', '#ffffff', '#ffffff']);
+    alert(`🎉 "${customName}" added to your collection!`);
+  };
+
+  // Filter master list based on active tab
+  const displayedPalettes = activeTab === 'all' 
+    ? allPalettes 
+    : allPalettes.filter(p => favorites.includes(p.name));
+
+  return (
+    <div className="color-wall-page">
+      <Navbar />
+      
+      <main className="color-wall-main">
+        <div className="color-wall-header">
+          <h1>🎨 Color Wall</h1>
+          <p>Explore, save, and test beautiful color combinations.</p>
+        </div>
+
+        {/* ── CUSTOM PALETTE BUILDER FORM ── */}
+        <section className="builder-section">
+          <h2>Create Custom Palette</h2>
+          <form onSubmit={handleSaveCustomPalette} className="builder-form">
+            <div className="builder-inputs">
+              <input 
+                type="text" 
+                placeholder="Name your palette (e.g., Midnight Cyber)" 
+                value={customName}
+                onChange={(e) => setCustomName(e.target.value)}
+                className="builder-text-input"
+              />
+              <button type="submit" className="builder-submit-btn">Save Palette</button>
+            </div>
+
+            <div className="builder-pickers">
+              {customColors.map((color, index) => (
+                <div key={index} className="picker-container">
+                  <input 
+                    type="color" 
+                    value={color} 
+                    onChange={(e) => handleColorChange(index, e.target.value)}
+                    className="color-picker-input"
+                  />
+                  <span className="picker-hex-label">{color.toUpperCase()}</span>
+                </div>
+              ))}
+            </div>
+          </form>
+        </section>
+
+        {/* ── PALETTE EXPLORER ── */}
+        <section className="color-wall-section">
+          <div className="wall-tabs">
+            <button 
+              className={`wall-tab ${activeTab === 'all' ? 'active' : ''}`}
+              onClick={() => setActiveTab('all')}
+            >
+              All Palettes ({allPalettes.length})
+            </button>
+            <button 
+              className={`wall-tab ${activeTab === 'favorites' ? 'active' : ''}`}
+              onClick={() => setActiveTab('favorites')}
+            >
+              My Favorites ({favorites.length})
+            </button>
+          </div>
+          
+          <div className="palette-grid">
+            {displayedPalettes.length === 0 ? (
+              <p className="empty-state">No palettes found here!</p>
+            ) : (
+              displayedPalettes.map((preset, index) => (
+                <div key={index} className="palette-card">
+                  
+                  <div className="palette-swatches">
+                    {preset.colors.map((color, idx) => (
+                      <div
+                        key={idx}
+                        className="swatch"
+                        style={{ backgroundColor: color }}
+                        title={`Copy ${color}`}
+                        onClick={() => handleCopy(color)}
+                      ></div>
+                    ))}
+                  </div>
+
+                  <div className="palette-info">
+                    <div className="palette-info-header">
+                      <h3>
+                        {preset.name}
+                        {preset.isCustom && <span className="custom-badge">Custom</span>}
+                      </h3>
+                      <button 
+                        className="favorite-btn" 
+                        onClick={() => toggleFavorite(preset.name)}
+                      >
+                        {favorites.includes(preset.name) ? '❤️' : '🤍'}
+                      </button>
+                    </div>
+
+                    <div className="hex-codes">
+                      {preset.colors.map((color, idx) => (
+                        <span 
+                          key={idx} 
+                          className="clickable-hex"
+                          onClick={() => handleCopy(color)}
+                        >
+                          {color}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+      </main>
+
+      {copiedColor && (
+        <div className="copy-toast">
+            🎨 Copied <strong>{copiedColor}</strong> to clipboard! 🎨
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ColorWall;

--- a/src/pages/ColorWall.jsx
+++ b/src/pages/ColorWall.jsx
@@ -2,6 +2,27 @@ import React, { useState, useEffect } from 'react';
 import Navbar from '../components/Navbar/Navbar.jsx';
 import './ColorWall.css';
 
+//  WCAG CONTRAST 
+const getLuminance = (hex) => {
+  const rgb = parseInt(hex.replace('#', ''), 16);
+  const r = (rgb >> 16) & 0xff;
+  const g = (rgb >> 8) & 0xff;
+  const b = (rgb >> 0) & 0xff;
+  const [R, G, B] = [r, g, b].map(c => {
+    c /= 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+};
+
+const getContrastRatio = (hex1, hex2) => {
+  const lum1 = getLuminance(hex1);
+  const lum2 = getLuminance(hex2);
+  const brightest = Math.max(lum1, lum2);
+  const darkest = Math.min(lum1, lum2);
+  return ((brightest + 0.05) / (darkest + 0.05)).toFixed(2);
+};
+
 const defaultPresets = [
   { name: 'Ocean Breeze', colors: ['#0f172a', '#0ea5e9', '#38bdf8', '#e0f2fe'] },
   { name: 'Sunset Glow', colors: ['#4c0519', '#e11d48', '#fb923c', '#ffedd5'] },
@@ -11,10 +32,10 @@ const defaultPresets = [
 
 function ColorWall() {
   const [copiedColor, setCopiedColor] = useState(null);
+  const [savedPaletteName, setSavedPaletteName] = useState(null);
   const [activeTab, setActiveTab] = useState('all');
 
-  // PHASE 3 STATE
-  // Initialize custom palettes from local storage
+  // 3 - Initialize custom palettes from local storage
   const [customPalettes, setCustomPalettes] = useState(() => {
     const savedCustom = localStorage.getItem('uiverse-custom-palettes');
     return savedCustom ? JSON.parse(savedCustom) : [];
@@ -24,10 +45,17 @@ function ColorWall() {
   const [customName, setCustomName] = useState('');
   const [customColors, setCustomColors] = useState(['#ffffff', '#ffffff', '#ffffff', '#ffffff']);
 
+  // 4 - contrast
+  const [compareBg, setCompareBg] = useState('#f4f6fb');
+  const [compareText, setCompareText] = useState('#1a1a2e');
+  const contrastScore = getContrastRatio(compareBg, compareText);
+  // 4.5 is the official WCAG AA standard for normal text readability
+  const isAccessible = contrastScore >= 4.5;
+
   // Combine default presets and user-created custom palettes into one master list
   const allPalettes = [...customPalettes, ...defaultPresets];
 
-  // ── PHASE 2 STATE (Favorites) ──
+  // 2 - favorites
   const [favorites, setFavorites] = useState(() => {
     const savedFavs = localStorage.getItem('uiverse-favorites');
     return savedFavs ? JSON.parse(savedFavs) : [];
@@ -57,7 +85,7 @@ function ColorWall() {
     }
   };
 
-  // PHASE 3 FUNCTIONS 
+  // 3 - FUNCTIONS 
   // Handles updating a specific color slot (0 to 3) when a picker changes
   const handleColorChange = (index, value) => {
     const updatedColors = [...customColors];
@@ -79,7 +107,8 @@ function ColorWall() {
     setCustomPalettes([newPalette, ...customPalettes]);
     setCustomName(''); // Reset input field
     setCustomColors(['#ffffff', '#ffffff', '#ffffff', '#ffffff']);
-    alert(`🎉 "${customName}" added to your collection!`);
+    setSavedPaletteName(customName);
+    setTimeout(() => setSavedPaletteName(null), 2500);
   };
 
   // Filter master list based on active tab
@@ -88,12 +117,13 @@ function ColorWall() {
     : allPalettes.filter(p => favorites.includes(p.name));
 
   return (
+    
     <div className="color-wall-page">
       <Navbar />
       
       <main className="color-wall-main">
         <div className="color-wall-header">
-          <h1>🎨 Color Wall</h1>
+          <h1>🎨 Color Wall 🎨</h1>
           <p>Explore, save, and test beautiful color combinations.</p>
         </div>
 
@@ -196,11 +226,60 @@ function ColorWall() {
             )}
           </div>
         </section>
+
+            
+        {/* 4 - CONTRAST CHECKER */}
+        <section className="contrast-section">
+          <h2>Contrast Checker - WCAG</h2>
+          <div className="contrast-container">
+            
+            <div className="contrast-controls">
+              <div className="control-group">
+                <label>Background Color</label>
+                <div className="picker-wrapper">
+                  <input type="color" value={compareBg} onChange={(e) => setCompareBg(e.target.value)} />
+                  <span>{compareBg.toUpperCase()}</span>
+                </div>
+              </div>
+              
+              <div className="control-group">
+                <label>Text Color</label>
+                <div className="picker-wrapper">
+                  <input type="color" value={compareText} onChange={(e) => setCompareText(e.target.value)} />
+                  <span>{compareText.toUpperCase()}</span>
+                </div>
+              </div>
+
+              <div className="contrast-score">
+                <div className="score-number">{contrastScore} : 1</div>
+                <div className={`score-badge ${isAccessible ? 'pass' : 'fail'}`}>
+                  {isAccessible ? '🌳 Pass' : '🚩  Fail'}
+                </div>
+              </div>
+            </div>
+
+            <div 
+              className="contrast-preview" 
+              style={{ backgroundColor: compareBg, color: compareText }}
+            >
+              <h3>Readability Preview</h3>
+              <p>Choosing the right colors ensures that everyone, including visually impaired users, can comfortably read your content.</p>
+            </div>
+            
+          </div>
+        </section>
+
       </main>
 
       {copiedColor && (
         <div className="copy-toast">
             🎨 Copied <strong>{copiedColor}</strong> to clipboard! 🎨
+        </div>
+      )}
+
+      {savedPaletteName && (
+        <div className="copy-toast">
+          🧑‍🎨 <strong>{savedPaletteName}</strong> added to your collection! 👩‍🎨
         </div>
       )}
     </div>

--- a/src/pages/ColorWall.jsx
+++ b/src/pages/ColorWall.jsx
@@ -110,6 +110,16 @@ function ColorWall() {
     setSavedPaletteName(customName);
     setTimeout(() => setSavedPaletteName(null), 2500);
   };
+  // ── delete custom palette ──
+  const deleteCustomPalette = (paletteName) => {
+    // remove from custom palettes
+    setCustomPalettes(customPalettes.filter(p => p.name !== paletteName));
+    
+    // if favorite -> remove from there too
+    if (favorites.includes(paletteName)) {
+      setFavorites(favorites.filter(name => name !== paletteName));
+    }
+  };
 
   // Filter master list based on active tab
   const displayedPalettes = activeTab === 'all' 
@@ -127,7 +137,7 @@ function ColorWall() {
           <p>Explore, save, and test beautiful color combinations.</p>
         </div>
 
-        {/* ── CUSTOM PALETTE BUILDER FORM ── */}
+        {/* CUSTOM PALETTE BUILDER FORM */}
         <section className="builder-section">
           <h2>Create Custom Palette</h2>
           <form onSubmit={handleSaveCustomPalette} className="builder-form">
@@ -158,7 +168,7 @@ function ColorWall() {
           </form>
         </section>
 
-        {/* ── PALETTE EXPLORER ── */}
+        {/* PALETTE EXPLORER */}
         <section className="color-wall-section">
           <div className="wall-tabs">
             <button 
@@ -197,15 +207,29 @@ function ColorWall() {
                   <div className="palette-info">
                     <div className="palette-info-header">
                       <h3>
-                        {preset.name}
+                        {preset.name} 
                         {preset.isCustom && <span className="custom-badge">Custom</span>}
                       </h3>
-                      <button 
-                        className="favorite-btn" 
-                        onClick={() => toggleFavorite(preset.name)}
-                      >
-                        {favorites.includes(preset.name) ? '❤️' : '🤍'}
-                      </button>
+                      
+                      {/* Grouping the buttons together */}
+                      <div className="palette-actions">
+                        {/* Only show the trash can IF it is a custom palette */}
+                        {preset.isCustom && (
+                          <button 
+                            className="delete-btn" 
+                            onClick={() => deleteCustomPalette(preset.name)}
+                            title="Delete custom palette"
+                          >
+                            🗑️
+                          </button>
+                        )}
+                        <button 
+                          className="favorite-btn" 
+                          onClick={() => toggleFavorite(preset.name)}
+                        >
+                          {favorites.includes(preset.name) ? '❤️' : '🤍'}
+                        </button>
+                      </div>
                     </div>
 
                     <div className="hex-codes">


### PR DESCRIPTION
Added a dedicated Color Wall page (/color-wall) to help users explore, save, and test UI color schemes natively.

Key Features Built:
- Preset Gallery: Curated palettes with 1-click hex copying and smooth toast notifications.
- Favorites System: Users can heart / favorite palettes to save them persistently via localStorage.
- Custom Builder: Added color inputs allowing users to build, name, and delete their own custom palettes.
- Contrast Checker: A built-in WCAG readability calculator (AA standards) to test text vs. background accessibility in real-time.
- Navigation: Seamlessly integrated the new route into the main Navbar.

feature/color-wall

Closes #19 
<img width="1470" height="834" alt="Screenshot 2026-05-21 at 8 15 20 PM" src="https://github.com/user-attachments/assets/0f97ed28-bda1-4630-9dc0-c512e1e3362d" />
<img width="1470" height="834" alt="Screenshot 2026-05-21 at 8 15 32 PM" src="https://github.com/user-attachments/assets/16cf58e8-ba12-4cb4-9cde-71fe354b04b4" />
<img width="1470" height="835" alt="Screenshot 2026-05-21 at 8 16 34 PM" src="https://github.com/user-attachments/assets/e11e08be-cf1b-490e-9be1-1ad17446c11a" />
<img width="1470" height="836" alt="Screenshot 2026-05-21 at 8 19 29 PM" src="https://github.com/user-attachments/assets/2d58de3b-ac53-4743-9410-75e6c8749e27" />
