### PR TITLE
feat: add global reusable back-to-top floating button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,19 +6,25 @@ import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home.jsx'
 import Components from './pages/Components.jsx'
 import GettingStarted from './pages/GettingStarted.jsx'
+import ScrollToTop from './components/ScrollToTop/ScrollToTop.jsx'
 
 function App() {
   return (
-    <Routes>
-      {/* Home page – landing screen */}
-      <Route path="/" element={<Home />} />
+    <>
+      <Routes>
+        {/* Home page – landing screen */}
+        <Route path="/" element={<Home />} />
 
-      {/* Components showcase page */}
-      <Route path="/components" element={<Components />} />
+        {/* Components showcase page */}
+        <Route path="/components" element={<Components />} />
 
-      {/* Getting Started / documentation page */}
-      <Route path="/docs" element={<GettingStarted />} />
-    </Routes>
+        {/* Getting Started / documentation page */}
+        <Route path="/docs" element={<GettingStarted />} />
+      </Routes>
+      
+      {/* Global "Back to Top" floating action button */}
+      <ScrollToTop />
+    </>
   )
 }
 

--- a/src/components/ScrollToTop/ScrollToTop.css
+++ b/src/components/ScrollToTop/ScrollToTop.css
@@ -1,0 +1,68 @@
+/* ScrollToTop.css */
+
+.scroll-to-top {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--brand, #4f46e5), var(--brand-2, #a855f7));
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 999;
+  
+  /* Initial hidden state with interactive transitions */
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(20px) scale(0.8);
+  box-shadow: 0 4px 14px rgba(79, 70, 229, 0.25);
+  transition: 
+    opacity 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.4s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.3s ease,
+    background-color 0.3s ease;
+}
+
+/* Visible State */
+.scroll-to-top--visible {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+}
+
+/* Hover State */
+.scroll-to-top--visible:hover {
+  transform: translateY(-5px) scale(1.08);
+  box-shadow: var(--shadow-brand, 0 8px 28px rgba(79, 70, 229, 0.45));
+  background: linear-gradient(135deg, var(--brand-dark, #4338ca), var(--brand-2, #a855f7));
+}
+
+/* Active State */
+.scroll-to-top--visible:active {
+  transform: translateY(-2px) scale(0.96);
+  box-shadow: 0 4px 10px rgba(79, 70, 229, 0.3);
+}
+
+/* Icon Micro-animation */
+.scroll-to-top-icon {
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.scroll-to-top--visible:hover .scroll-to-top-icon {
+  transform: translateY(-2px);
+}
+
+/* Mobile Responsiveness */
+@media (max-width: 768px) {
+  .scroll-to-top {
+    bottom: 24px;
+    right: 24px;
+    width: 44px;
+    height: 44px;
+  }
+}

--- a/src/components/ScrollToTop/ScrollToTop.jsx
+++ b/src/components/ScrollToTop/ScrollToTop.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react'
+import './ScrollToTop.css'
+
+function ScrollToTop() {
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true)
+      } else {
+        setIsVisible(false)
+      }
+    }
+
+    window.addEventListener('scroll', toggleVisibility)
+    return () => window.removeEventListener('scroll', toggleVisibility)
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }
+
+  return (
+    <button
+      className={`scroll-to-top ${isVisible ? 'scroll-to-top--visible' : ''}`}
+      onClick={scrollToTop}
+      aria-label="Back to Top"
+      title="Back to Top"
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="scroll-to-top-icon"
+      >
+        <polyline points="18 15 12 9 6 15" />
+      </svg>
+    </button>
+  )
+}
+
+export default ScrollToTop

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -328,24 +328,3 @@
   background: var(--surface);
 }
 
-.scroll-top-btn {
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  width: 52px;
-  height: 52px;
-  border: none;
-  border-radius: 50%;
-  background: #111827;
-  color: #fff;
-  font-size: 24px;
-  cursor: pointer;
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
-  transition: all 0.3s ease;
-  z-index: 1000;
-}
-
-.scroll-top-btn:hover {
-  transform: translateY(-4px) scale(1.05);
-  opacity: 0.9;
-}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,30 +1,12 @@
 // Home.jsx – Landing page of UIverse
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import Button from "../components/Button/Button.jsx";
 import Navbar from "../components/Navbar/Navbar.jsx";
 import "./Home.css";
 
 function Home() {
-  const [showButton, setShowButton] = useState(false);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      setShowButton(window.scrollY > 300);
-    };
-
-    window.addEventListener("scroll", handleScroll);
-
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
-    });
-  };
   return (
     <div className="home-page">
       <Navbar />
@@ -146,11 +128,6 @@ function Home() {
       </section>
 
       {/* ── Footer ── */}
-      {showButton && (
-        <button className="scroll-top-btn" onClick={scrollToTop}>
-          ↑
-        </button>
-      )}
       <footer className="home-footer">
         <p>Made with care for the open-source community · UIverse 2025</p>
       </footer>


### PR DESCRIPTION
### Closes #65


### What I did:

- **Created a reusable `ScrollToTop` component**: Grouped the logic and co-located styles into a dedicated component folder under `src/components/ScrollToTop/` (`ScrollToTop.jsx` and `ScrollToTop.css`).

- **Global Integration**: Mounted `<ScrollToTop />` globally in `App.jsx` next to the `<Routes />`. This ensures all present and future pages—especially the lengthy Components and Docs screens—get the scroll-to-top feature automatically.

- **Scroll Position Tracking**: Implemented a window scroll event listener inside a `useEffect` hook. It toggles visibility state once the scroll position exceeds `300px` and cleanly unsubscribes when the component unmounts.

- **Code Cleanup**: Completely removed the duplicate inline scroll states, helpers, and CSS rules from the Home page (`Home.jsx` / `Home.css`) so the codebase remains DRY.


### Design & Styling:

- **Theme Support**: Hooked the button background and border into the project's existing CSS variables (`--brand`, `--brand-2`, etc.) to guarantee seamless light and dark theme compatibility.

- **Micro-Animations**: Set up transition timing functions for smooth entrance/exit. Added interactive hover states that scale the button, elevate the shadow glow, and translate the chevron icon slightly upward.

- **Responsiveness**: Added media queries that scale the button down on mobile viewports so it doesn't obstruct readable text or footer elements.


### How I Tested:

- Ran the local Vite dev server and verified button transitions and click-actions across all pages (Home, Components, Docs).

- Executed `npm run build` to confirm successful production bundling with zero errors or warnings.