### PR TITLE
Feat: Added Ai generator component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+.env
 dist
 dist-ssr
 *.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "uiverse",
       "version": "1.0.0",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.6.0",
@@ -689,6 +690,15 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.6.0",

--- a/src/lib/ai.js
+++ b/src/lib/ai.js
@@ -1,0 +1,36 @@
+const FREE_MODELS = [
+  "openrouter/auto",
+  "qwen/qwen3-coder:free",
+  "deepseek/deepseek-v3:free",
+  "meta-llama/llama-3.3-70b-instruct:free",
+];
+
+export async function generateComponent(prompt) {
+  for (const model of FREE_MODELS) {
+    try {
+      const response = await fetch(
+        "https://openrouter.ai/api/v1/chat/completions",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`,
+          },
+          body: JSON.stringify({
+            model,
+            messages: [{ role: "user", content: prompt }],
+          }),
+        },
+      );
+
+      const data = await response.json();
+      if (data.choices?.[0]?.message?.content) {
+        return data.choices[0].message.content;
+      }
+    } catch (e) {
+      continue;
+    }
+  }
+
+  throw new Error("All models failed");
+}

--- a/src/pages/Components.css
+++ b/src/pages/Components.css
@@ -47,7 +47,9 @@
   background: none;
   border: none;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
   margin-bottom: 2px;
   text-decoration: none;
 }
@@ -77,7 +79,9 @@
   padding-left: 10px;
 }
 
-.sidebar-item--link { color: var(--brand); }
+.sidebar-item--link {
+  color: var(--brand);
+}
 
 .sidebar-divider {
   height: 1px;
@@ -86,9 +90,14 @@
 }
 
 /* ── Main ── */
-.comp-main { flex: 1; min-width: 0; }
+.comp-main {
+  flex: 1;
+  min-width: 0;
+}
 
-.comp-header { margin-bottom: 36px; }
+.comp-header {
+  margin-bottom: 36px;
+}
 
 .comp-header h1 {
   font-size: 2.2rem;
@@ -136,7 +145,9 @@
 }
 
 /* ── Subsection ── */
-.comp-subsection { margin-bottom: 28px; }
+.comp-subsection {
+  margin-bottom: 28px;
+}
 
 .comp-subsection-title {
   font-size: 0.75rem;
@@ -156,13 +167,16 @@
   padding: 32px;
   background:
     linear-gradient(var(--surface-2) 0%, var(--surface-2) 100%),
-    repeating-conic-gradient(var(--border) 0% 25%, transparent 0% 50%) 0 0 / 20px 20px;
+    repeating-conic-gradient(var(--border) 0% 25%, transparent 0% 50%) 0 0 /
+      20px 20px;
   background-blend-mode: normal;
   border: 1px solid var(--border);
   border-radius: 12px;
 }
 
-.comp-preview--align-end { align-items: flex-end; }
+.comp-preview--align-end {
+  align-items: flex-end;
+}
 
 /* ── Code block ── */
 .code-block {
@@ -171,7 +185,7 @@
   overflow: hidden;
   margin-bottom: 28px;
   border: 1px solid var(--code-border);
-  box-shadow: 0 4px 20px rgba(0,0,0,0.2);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
 }
 
 .code-block-header {
@@ -195,25 +209,27 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  background: rgba(99,102,241,0.15);
-  border: 1px solid rgba(99,102,241,0.3);
+  background: rgba(99, 102, 241, 0.15);
+  border: 1px solid rgba(99, 102, 241, 0.3);
   color: #a5b4fc;
   font-size: 0.8rem;
   padding: 4px 12px;
   border-radius: 6px;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
   font-family: inherit;
 }
 
 .copy-btn:hover {
-  background: rgba(99,102,241,0.28);
-  border-color: rgba(99,102,241,0.5);
+  background: rgba(99, 102, 241, 0.28);
+  border-color: rgba(99, 102, 241, 0.5);
 }
 
 .code-block pre {
   color: var(--code-text);
-  font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  font-family: "JetBrains Mono", "Fira Code", "Courier New", monospace;
   font-size: 0.9rem;
   line-height: 1.8;
   padding: 22px;
@@ -222,7 +238,9 @@
 }
 
 /* ── Props table ── */
-.props-table-wrap { overflow-x: auto; }
+.props-table-wrap {
+  overflow-x: auto;
+}
 
 .props-table {
   width: 100%;
@@ -245,7 +263,9 @@
   color: var(--text-2);
 }
 
-.props-table tr:last-child td { border-bottom: none; }
+.props-table tr:last-child td {
+  border-bottom: none;
+}
 
 .props-table code {
   background: var(--accent);
@@ -256,7 +276,9 @@
 }
 
 /* ── All components table ── */
-.comp-table-wrap { overflow-x: auto; }
+.comp-table-wrap {
+  overflow-x: auto;
+}
 
 .comp-table {
   width: 100%;
@@ -279,7 +301,9 @@
   color: var(--text-2);
 }
 
-.comp-table tr:last-child td { border-bottom: none; }
+.comp-table tr:last-child td {
+  border-bottom: none;
+}
 
 .category-tag {
   background: var(--surface-2);
@@ -321,15 +345,15 @@
 }
 
 [data-theme="dark"] .comp-badge--stable {
-  background: rgba(21,128,61,0.2);
+  background: rgba(21, 128, 61, 0.2);
   color: #4ade80;
-  border-color: rgba(74,222,128,0.25);
+  border-color: rgba(74, 222, 128, 0.25);
 }
 
 [data-theme="dark"] .comp-badge--beta {
-  background: rgba(161,98,7,0.2);
+  background: rgba(161, 98, 7, 0.2);
   color: #fbbf24;
-  border-color: rgba(251,191,36,0.25);
+  border-color: rgba(251, 191, 36, 0.25);
 }
 
 /* ── Responsive ── */
@@ -349,7 +373,57 @@
   }
 
   .sidebar-label,
-  .sidebar-divider { display: none; }
+  .sidebar-divider {
+    display: none;
+  }
 
-  .comp-section { padding: 20px; }
+  .comp-section {
+    padding: 20px;
+  }
+}
+.ai-generator-wrapper {
+  width: 100%;
+  margin-bottom: 3rem;
+}
+
+.ai-generator-card {
+  max-width: 760px;
+  background: #fff;
+  border: 1px solid #ececec;
+  border-radius: 24px;
+  padding: 2.2rem;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
+}
+
+.ai-generator-box {
+  display: flex;
+  gap: 14px;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.ai-generator-input {
+  flex: 1;
+  min-width: 260px;
+  background: #0f172a;
+  border: 1px solid #2a2a2a;
+  color: white;
+  padding: 14px 16px;
+  border-radius: 12px;
+  outline: none;
+  font-size: 0.95rem;
+}
+
+.ai-generator-btn {
+  background: linear-gradient(135deg, #7c3aed, #9333ea);
+  border: none;
+  color: white;
+  padding: 14px 22px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.ai-preview-box {
+  margin-top: 1.5rem;
 }

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -1,90 +1,165 @@
 // Components.jsx – Component showcase page
 
-import React, { useState } from 'react'
-import Button from '../components/Button/Button.jsx'
-import Navbar from '../components/Navbar/Navbar.jsx'
-import Badge from '../components/Badge/Badge.jsx'
-import { componentsList } from '../data/componentsList.js'
-import './Components.css'
+import React, { useState } from "react";
+import Button from "../components/Button/Button.jsx";
+import Navbar from "../components/Navbar/Navbar.jsx";
+import Badge from "../components/Badge/Badge.jsx";
+import { componentsList } from "../data/componentsList.js";
+import "./Components.css";
+import { generateComponent as aiGenerate } from "../lib/ai.js";
 
 /* ================= SECTIONS ================= */
 
 const sections = [
   {
-    id: 'buttons',
-    label: 'Buttons',
+    id: "buttons",
+    label: "Buttons",
     icon: (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <rect x="3" y="8" width="18" height="8" rx="3"/>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <rect x="3" y="8" width="18" height="8" rx="3" />
       </svg>
     ),
   },
   {
-    id: 'badges',
-    label: 'Badges',
+    id: "badges",
+    label: "Badges",
     icon: (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M12 2l4 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L1 9h7z"/>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M12 2l4 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L1 9h7z" />
       </svg>
     ),
   },
   {
-    id: 'all-components',
-    label: 'All Components',
+    id: "all-components",
+    label: "All Components",
     icon: (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <line x1="8" y1="6" x2="21" y2="6"/>
-        <line x1="8" y1="12" x2="21" y2="12"/>
-        <line x1="8" y1="18" x2="21" y2="18"/>
-        <line x1="3" y1="6" x2="3.01" y2="6"/>
-        <line x1="3" y1="12" x2="3.01" y2="12"/>
-        <line x1="3" y1="18" x2="3.01" y2="18"/>
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <line x1="8" y1="6" x2="21" y2="6" />
+        <line x1="8" y1="12" x2="21" y2="12" />
+        <line x1="8" y1="18" x2="21" y2="18" />
+        <line x1="3" y1="6" x2="3.01" y2="6" />
+        <line x1="3" y1="12" x2="3.01" y2="12" />
+        <line x1="3" y1="18" x2="3.01" y2="18" />
       </svg>
     ),
   },
-]
+  {
+    id: "ai-generator",
+    label: "AI Generator",
+    icon: (
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M12 2v4" />
+        <path d="M12 18v4" />
+        <path d="M4.93 4.93l2.83 2.83" />
+        <path d="M16.24 16.24l2.83 2.83" />
+        <path d="M2 12h4" />
+        <path d="M18 12h4" />
+        <path d="M4.93 19.07l2.83-2.83" />
+        <path d="M16.24 7.76l2.83-2.83" />
+      </svg>
+    ),
+  },
+];
 
 /* ================= ICONS ================= */
 
 const CopyIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <rect x="9" y="9" width="13" height="13" rx="2"/>
-    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
   </svg>
-)
+);
 
 const CheckIcon = () => (
-  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-    <polyline points="20 6 9 17 4 12"/>
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+  >
+    <polyline points="20 6 9 17 4 12" />
   </svg>
-)
+);
 
 /* ================= COMPONENT ================= */
 
 function Components() {
-  const [activeSection, setActiveSection] = useState('buttons')
-  const [copied, setCopied] = useState(false)
-
+  const [activeSection, setActiveSection] = useState("buttons");
+  const [copied, setCopied] = useState(false);
+  const [prompt, setPrompt] = useState("");
+  const [generatedCode, setGeneratedCode] = useState("");
+  const [loading, setLoading] = useState(false);
   const handleCopy = (code) => {
-    navigator.clipboard.writeText(code)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1800)
-  }
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  };
 
   const scrollTo = (id) => {
-    setActiveSection(id)
+    setActiveSection(id);
     document.getElementById(id)?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'start',
-    })
-  }
-
+      behavior: "smooth",
+      block: "start",
+    });
+  };
+  const generateComponent = async () => {
+    if (!prompt.trim()) return;
+    try {
+      setLoading(true);
+      const text = await aiGenerate(`
+      Generate a reusable React JSX UI component.
+      Requirements: Return ONLY JSX code, no explanations, modern UI, Tailwind CSS only.
+      Prompt: ${prompt}
+    `);
+      setGeneratedCode(text);
+    } catch (error) {
+      setGeneratedCode("Failed to generate component.");
+    } finally {
+      setLoading(false);
+    }
+  };
   return (
     <div className="comp-page">
       <Navbar />
 
       <div className="comp-layout">
-
         {/* ================= SIDEBAR ================= */}
         <aside className="comp-sidebar">
           <p className="sidebar-label">ON THIS PAGE</p>
@@ -111,8 +186,15 @@ function Components() {
             className="sidebar-item sidebar-item--link"
           >
             <span className="sidebar-item-icon">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
               </svg>
             </span>
             GitHub Repo
@@ -121,12 +203,63 @@ function Components() {
 
         {/* ================= MAIN ================= */}
         <main className="comp-main">
-
           <div className="comp-header">
             <h1>Components</h1>
-            <p>Production-ready UI components. Copy the code, drop it in, done.</p>
+            <p>
+              Production-ready UI components. Copy the code, drop it in, done.
+            </p>
           </div>
+          <section className="comp-section" id="ai-generator">
+            <div className="comp-section-header">
+              <h2>AI Component Generator</h2>
+              <span className="comp-badge comp-badge--stable">AI</span>
+            </div>
 
+            <p className="comp-section-desc">
+              Generate reusable React UI components using Gemini AI.
+            </p>
+
+            <div className="ai-generator-box">
+              <input
+                type="text"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                placeholder="Create a modern purple pricing card"
+                className="ai-generator-input"
+              />
+
+              <button className="ai-generator-btn" onClick={generateComponent}>
+                {loading ? "Generating..." : "Generate Component"}
+              </button>
+            </div>
+
+            {generatedCode && (
+              <div className="ai-preview-box">
+                <div className="code-block">
+                  <div className="code-block-header">
+                    <span>Generated JSX</span>
+
+                    <button
+                      className="copy-btn"
+                      onClick={() => handleCopy(generatedCode)}
+                    >
+                      {copied ? (
+                        <>
+                          <CheckIcon /> Copied
+                        </>
+                      ) : (
+                        <>
+                          <CopyIcon /> Copy
+                        </>
+                      )}
+                    </button>
+                  </div>
+
+                  <pre>{generatedCode}</pre>
+                </div>
+              </div>
+            )}
+          </section>
           {/* ================= BUTTONS ================= */}
           <section className="comp-section" id="buttons">
             <div className="comp-section-header">
@@ -206,7 +339,9 @@ function Components() {
                 <tbody>
                   {componentsList.map((c) => (
                     <tr key={c.id}>
-                      <td><strong>{c.name}</strong></td>
+                      <td>
+                        <strong>{c.name}</strong>
+                      </td>
                       <td>{c.category}</td>
                       <td>{c.status}</td>
                       <td>{c.description}</td>
@@ -216,11 +351,10 @@ function Components() {
               </table>
             </div>
           </section>
-
         </main>
       </div>
     </div>
-  )
+  );
 }
 
-export default Components
+export default Components;


### PR DESCRIPTION
Hi @ayushkashyap402 ,
I have added an AI-powered component generator to the Components page that allows users to generate reusable React JSX components from a text prompt.

Issue:
closes #52

<img width="1600" height="800" alt="image" src="https://github.com/user-attachments/assets/9f8ba84e-58bc-4891-b062-031fbd001266" />
<img width="1600" height="802" alt="image" src="https://github.com/user-attachments/assets/0642f1c5-cb5e-4bc2-b44e-11e0c3ec9fa1" />

Changes:
Added AI Component Generator section to Components.jsx with a prompt input and generate button
Created src/lib/ai.js with OpenRouter API integration and multi-model fallback support
Generator tries multiple free models (openrouter/auto, qwen/qwen3-coder:free, deepseek/deepseek-v3:free, llama-3.3-70b:free) in order for reliability
Generated JSX is displayed in a code block with a one-click copy button
Added VITE_OPENROUTER_API_KEY env variable support

How to test:
Add VITE_OPENROUTER_API_KEY to your .env file
Navigate to /components
Type a prompt like "create a modern purple pricing card"
Click Generate Component and copy the output

Additional context:
Requires a free [OpenRouter](https://openrouter.ai/) API key and no credit card needed


Kindly provide gssoc:approved labels