### PR TITLE
feat: Add reusable Navbar and Sidebar navigation components

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -1,266 +1,307 @@
-/* ================= ROOT VARIABLES ================= */
-:root {
-  --nav-text: #e5e7eb;
-  --nav-muted: #9ca3af;
-  --nav-primary: #4f46e5;
-  --nav-primary-light: #6366f1;
-  --nav-hover: rgba(255, 255, 255, 0.06);
+/* ================= REUSABLE NAVBAR COMPONENT ================= */
+/* Variants: default | transparent | solid | gradient              */
 
-  --surface: rgba(31, 34, 44, 0.85);
-  --border: rgba(255, 255, 255, 0.08);
-}
-
-/* ================= NAVBAR ================= */
-.navbar {
+/* ================= BASE ================= */
+.uiverse-navbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
 
-  padding: 0 32px;
-  height: 64px;
+  padding: 0 28px;
+  height: 60px;
+  width: 100%;
 
+  font-family: inherit;
+  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.uiverse-navbar--sticky {
   position: sticky;
   top: 0;
-  z-index: 1000;
-
-  background: var(--surface);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-
-  border-bottom: 1px solid var(--border);
-
-  transition: all 0.3s ease;
+  z-index: 100;
 }
 
-.navbar--scrolled {
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
+.uiverse-navbar--scrolled {
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
 }
 
-/* ================= LOGO ================= */
-.navbar-logo {
+/* ================= VARIANT: DEFAULT ================= */
+.uiverse-navbar--default {
+  background: rgba(15, 17, 24, 0.88);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.uiverse-navbar--default .uiverse-navbar-brand {
+  color: #f1f5f9;
+}
+
+.uiverse-navbar--default .uiverse-navbar-link {
+  color: #94a3b8;
+}
+
+.uiverse-navbar--default .uiverse-navbar-link:hover {
+  color: #f1f5f9;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* ================= VARIANT: TRANSPARENT ================= */
+.uiverse-navbar--transparent {
+  background: transparent;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.uiverse-navbar--transparent .uiverse-navbar-brand {
+  color: #f1f5f9;
+}
+
+.uiverse-navbar--transparent .uiverse-navbar-link {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.uiverse-navbar--transparent .uiverse-navbar-link:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* ================= VARIANT: SOLID ================= */
+.uiverse-navbar--solid {
+  background: #1e1b4b;
+  border-bottom: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+.uiverse-navbar--solid .uiverse-navbar-brand {
+  color: #e0e7ff;
+}
+
+.uiverse-navbar--solid .uiverse-navbar-link {
+  color: #a5b4fc;
+}
+
+.uiverse-navbar--solid .uiverse-navbar-link:hover {
+  color: #e0e7ff;
+  background: rgba(99, 102, 241, 0.15);
+}
+
+/* ================= VARIANT: GRADIENT ================= */
+.uiverse-navbar--gradient {
+  background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 50%, #a855f7 100%);
+  border-bottom: none;
+}
+
+.uiverse-navbar--gradient .uiverse-navbar-brand {
+  color: #fff;
+}
+
+.uiverse-navbar--gradient .uiverse-navbar-link {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.uiverse-navbar--gradient .uiverse-navbar-link:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+/* ================= BRAND ================= */
+.uiverse-navbar-brand {
   display: flex;
   align-items: center;
   gap: 10px;
 
-  text-decoration: none;
-  font-size: 1.2rem;
-  font-weight: 800;
-  letter-spacing: -0.5px;
-  color: white;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.3px;
 
+  cursor: default;
   transition: transform 0.2s ease;
 }
 
-.navbar-logo:hover {
+.uiverse-navbar-brand:hover {
   transform: translateY(-1px);
 }
 
-.navbar-logo-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  font-size: 1.5rem;
-  color: var(--nav-primary-light);
-
-  filter: drop-shadow(0 0 8px rgba(99, 102, 241, 0.45));
+.uiverse-navbar-brand svg {
+  flex-shrink: 0;
+  opacity: 0.85;
 }
 
 /* ================= LINKS ================= */
-.navbar-links {
+.uiverse-navbar-links {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
-.navbar-link {
+.uiverse-navbar-link {
   position: relative;
-  padding: 10px 16px;
+  padding: 8px 16px;
   border-radius: 10px;
 
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   font-weight: 500;
-  color: var(--nav-muted);
   text-decoration: none;
 
   transition: all 0.25s ease;
 }
 
-.navbar-link:hover {
-  color: white;
-  background: var(--nav-hover);
-  transform: translateY(-1px);
-}
-
-/* Active Link */
-.navbar-link.active {
-  color: white;
-  background: rgba(99, 102, 241, 0.15);
-}
-
-/* Underline animation */
-.navbar-link::after {
+.uiverse-navbar-link::after {
   content: "";
   position: absolute;
   left: 16px;
-  bottom: 6px;
-  width: 0%;
+  bottom: 4px;
+  width: 0;
   height: 2px;
-  background: var(--nav-primary-light);
   border-radius: 999px;
+  background: currentColor;
+  opacity: 0.5;
   transition: width 0.25s ease;
 }
 
-.navbar-link:hover::after,
-.navbar-link.active::after {
+.uiverse-navbar-link:hover::after {
   width: calc(100% - 32px);
 }
 
-/* ================= GITHUB BUTTON ================= */
-.navbar-github {
+/* ================= CTA BUTTON ================= */
+.uiverse-navbar-cta {
   margin-left: 8px;
+  padding: 8px 20px;
+  border-radius: 10px;
 
-  background: linear-gradient(
-    135deg,
-    var(--nav-primary),
-    var(--nav-primary-light)
-  );
-
-  color: white !important;
+  font-size: 0.88rem;
   font-weight: 600;
-  padding: 10px 16px;
-  border-radius: 12px;
+  text-decoration: none;
 
-  box-shadow: 0 6px 18px rgba(79, 70, 229, 0.28);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
 
   transition: all 0.25s ease;
 }
 
-.navbar-github:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 24px rgba(5, 1, 75, 0.4);
+.uiverse-navbar-cta:hover {
+  background: rgba(255, 255, 255, 0.25);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-/* ================= THEME TOGGLE ================= */
-.theme-toggle {
-  margin-left: 8px;
-
-  width: 36px;
-  height: 36px;
-
-  border-radius: 10px;
-  border: 1px solid var(--border);
-
-  background: rgba(255, 255, 255, 0.04);
-  color: white;
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  cursor: pointer;
-
-  transition: all 0.2s ease;
+/* Gradient variant CTA override */
+.uiverse-navbar--gradient .uiverse-navbar-cta {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.3);
 }
 
-.theme-toggle:hover {
-  background: rgba(99, 102, 241, 0.15);
-  transform: rotate(15deg) scale(1.05);
+.uiverse-navbar--gradient .uiverse-navbar-cta:hover {
+  background: rgba(255, 255, 255, 0.32);
 }
 
-.theme-toggle:active {
-  transform: rotate(180deg) scale(0.9);
+/* Default variant CTA override */
+.uiverse-navbar--default .uiverse-navbar-cta {
+  background: linear-gradient(135deg, #4f46e5, #6366f1);
+  border-color: transparent;
+  box-shadow: 0 4px 14px rgba(79, 70, 229, 0.3);
 }
 
-/* ================= MOBILE BUTTON ================= */
-.nav-btn {
+.uiverse-navbar--default .uiverse-navbar-cta:hover {
+  box-shadow: 0 6px 20px rgba(79, 70, 229, 0.45);
+}
+
+/* Solid variant CTA override */
+.uiverse-navbar--solid .uiverse-navbar-cta {
+  background: #4f46e5;
+  border-color: rgba(99, 102, 241, 0.4);
+  color: #e0e7ff;
+}
+
+.uiverse-navbar--solid .uiverse-navbar-cta:hover {
+  background: #5b52f0;
+}
+
+/* ================= MOBILE TOGGLE ================= */
+.uiverse-navbar-toggle {
   display: none;
 
-  width: 42px;
-  height: 42px;
+  width: 40px;
+  height: 40px;
 
   align-items: center;
   justify-content: center;
 
   border-radius: 10px;
-  border: 1px solid var(--border);
-
-  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
   color: white;
 
-  font-size: 1.3rem;
   cursor: pointer;
-
   transition: all 0.2s ease;
 }
 
-.nav-btn:hover {
-  background: rgba(99, 102, 241, 0.15);
+.uiverse-navbar-toggle:hover {
+  background: rgba(255, 255, 255, 0.12);
   transform: scale(1.05);
 }
 
-/* ================= MOBILE STYLES ================= */
+/* ================= MOBILE RESPONSIVE ================= */
 @media (max-width: 768px) {
-  .navbar {
+  .uiverse-navbar {
     padding: 0 20px;
-    height: 68px;
+    height: 64px;
   }
 
-  .nav-btn {
+  .uiverse-navbar-toggle {
     display: flex;
   }
 
-  .navbar-links {
+  .uiverse-navbar-links {
     position: absolute;
-    top: 80px;
-    right: 20px;
+    top: 72px;
+    right: 16px;
 
-    width: 230px;
+    width: 220px;
 
     display: none;
     flex-direction: column;
     align-items: stretch;
 
-    gap: 8px;
-    padding: 18px;
+    gap: 6px;
+    padding: 16px;
 
-    background: rgba(39, 43, 54, 0.96);
-
+    background: rgba(20, 22, 30, 0.97);
     backdrop-filter: blur(18px);
     -webkit-backdrop-filter: blur(18px);
 
-    border: 1px solid var(--border);
-    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
 
     box-shadow:
-      0 20px 40px rgba(0, 0, 0, 0.45),
+      0 16px 40px rgba(0, 0, 0, 0.4),
       inset 0 1px 0 rgba(255, 255, 255, 0.04);
 
-    animation: menuFade 0.25s ease;
+    animation: uiverseNavFade 0.25s ease;
   }
 
-  .navbar-links.active {
+  .uiverse-navbar-links--open {
     display: flex;
   }
 
-  .navbar-link {
+  .uiverse-navbar-link {
     width: 100%;
     padding: 12px 14px;
   }
 
-  .navbar-github {
+  .uiverse-navbar-cta {
+    margin-left: 0;
     margin-top: 6px;
     text-align: center;
   }
 }
 
 /* ================= ANIMATION ================= */
-@keyframes menuFade {
+@keyframes uiverseNavFade {
   from {
     opacity: 0;
-    transform: translateY(-10px) scale(0.98);
+    transform: translateY(-8px) scale(0.98);
   }
-
   to {
     opacity: 1;
     transform: translateY(0) scale(1);

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -1,10 +1,20 @@
+// Navbar.jsx – Reusable Navbar component
+//
+// Props:
+//   brand       (string)  – Brand / logo text displayed on the left
+//   links       (array)   – Array of { label, href } objects for nav links
+//   variant     (string)  – "default" | "transparent" | "solid" | "gradient"
+//   sticky      (boolean) – Whether the navbar sticks to the top on scroll (default: true)
+//   cta         (object)  – Optional CTA button: { label, href }
+//   onLinkClick (func)    – Optional callback when a link is clicked
+//
+// To add a new variant: add CSS class uiverse-navbar--<name> in Navbar.css
+
 import React, { useState, useEffect } from 'react'
-import { Link, useLocation } from 'react-router-dom'
 import './Navbar.css'
 
 /* ================= ICONS ================= */
 
-// Hamburger menu icon (replaces FaBars from react-icons)
 const BarsIcon = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
     <line x1="3" y1="6"  x2="21" y2="6"/>
@@ -13,7 +23,6 @@ const BarsIcon = () => (
   </svg>
 )
 
-// Close / X icon (replaces FaTimes from react-icons)
 const TimesIcon = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
     <line x1="18" y1="6"  x2="6"  y2="18"/>
@@ -21,124 +30,91 @@ const TimesIcon = () => (
   </svg>
 )
 
-const SunIcon = () => (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <circle cx="12" cy="12" r="5"/>
-    <line x1="12" y1="1" x2="12" y2="3"/>
-    <line x1="12" y1="21" x2="12" y2="23"/>
-  </svg>
-)
-
-const MoonIcon = () => (
-  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <path d="M21 12.79A9 9 0 1 1 11.21 3"/>
-  </svg>
-)
-
-const LogoIcon = () => (
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="url(#logo-grad)" strokeWidth="1.8">
-    <defs>
-      <linearGradient id="logo-grad">
-        <stop offset="0%" stopColor="#4f46e5"/>
-        <stop offset="100%" stopColor="#a855f7"/>
-      </linearGradient>
-    </defs>
+const DefaultBrandIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
     <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5"/>
   </svg>
 )
 
 /* ================= COMPONENT ================= */
 
-function Navbar() {
-  const location = useLocation()
-
+function Navbar({
+  brand = 'Brand',
+  links = [
+    { label: 'Home', href: '#' },
+    { label: 'About', href: '#' },
+    { label: 'Services', href: '#' },
+    { label: 'Contact', href: '#' },
+  ],
+  variant = 'default',
+  sticky = true,
+  cta = null,
+  onLinkClick = null,
+}) {
   const [scrolled, setScrolled] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
 
-  // Theme state
-  const [dark, setDark] = useState(() => {
-    const saved = localStorage.getItem('uiverse-theme')
-    if (saved) return saved === 'dark'
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-  })
-
-  /* ================= EFFECTS ================= */
-
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light')
-    localStorage.setItem('uiverse-theme', dark ? 'dark' : 'light')
-  }, [dark])
-
-  useEffect(() => {
+    if (!sticky) return
     const onScroll = () => setScrolled(window.scrollY > 10)
     window.addEventListener('scroll', onScroll)
     return () => window.removeEventListener('scroll', onScroll)
-  }, [])
+  }, [sticky])
 
-  /* ================= HANDLERS ================= */
-
-  const toggleTheme = () => {
-    setDark(prev => !prev)
-  }
-
-  const handleOpenNavbar = () => {
-    setIsOpen(prev => !prev)
-  }
-
-  const closeMenu = () => {
+  const handleLinkClick = (link) => {
     setIsOpen(false)
+    if (onLinkClick) onLinkClick(link)
   }
 
-  /* ================= JSX ================= */
+  const navClasses = [
+    'uiverse-navbar',
+    `uiverse-navbar--${variant}`,
+    sticky ? 'uiverse-navbar--sticky' : '',
+    scrolled ? 'uiverse-navbar--scrolled' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
-    <nav className={`navbar ${scrolled ? 'navbar--scrolled' : ''}`}>
-
-      {/* LOGO */}
-      <Link to="/" className="navbar-logo" onClick={closeMenu}>
-        <LogoIcon />
-        UIverse
-      </Link>
-
-      {/* LINKS */}
-      <div className={`navbar-links ${isOpen ? "active" : ""}`}>
-
-        <Link to="/" onClick={closeMenu}
-          className={`navbar-link ${location.pathname === '/' ? 'active' : ''}`}>
-          Home
-        </Link>
-
-        <Link to="/components" onClick={closeMenu}
-          className={`navbar-link ${location.pathname === '/components' ? 'active' : ''}`}>
-          Components
-        </Link>
-        {/* Get Started CTA (links to docs page) */}
-        <Link
-          to="/docs"
-          className="navbar-link navbar-github"
-          onClick={closeMenu}
-        >
-          Get Started
-        </Link>
-
-        {/* Theme Toggle */}
-        <button
-          className="theme-toggle"
-          onClick={toggleTheme}
-        >
-          {dark ? <SunIcon /> : <MoonIcon />}
-        </button>
-
+    <nav className={navClasses}>
+      {/* BRAND */}
+      <div className="uiverse-navbar-brand">
+        <DefaultBrandIcon />
+        <span className="uiverse-navbar-brand-text">{brand}</span>
       </div>
 
-      {/* MOBILE BUTTON */}
+      {/* LINKS */}
+      <div className={`uiverse-navbar-links ${isOpen ? 'uiverse-navbar-links--open' : ''}`}>
+        {links.map((link, i) => (
+          <a
+            key={i}
+            href={link.href}
+            className="uiverse-navbar-link"
+            onClick={() => handleLinkClick(link)}
+          >
+            {link.label}
+          </a>
+        ))}
+
+        {cta && (
+          <a
+            href={cta.href}
+            className="uiverse-navbar-cta"
+            onClick={() => handleLinkClick(cta)}
+          >
+            {cta.label}
+          </a>
+        )}
+      </div>
+
+      {/* MOBILE TOGGLE */}
       <button
-        onClick={handleOpenNavbar}
-        className="nav-btn"
+        className="uiverse-navbar-toggle"
+        onClick={() => setIsOpen(prev => !prev)}
+        aria-label="Toggle navigation"
       >
         {isOpen ? <TimesIcon /> : <BarsIcon />}
       </button>
-
     </nav>
   )
 }

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -1,0 +1,352 @@
+/* ================= BASE ================= */
+.uiverse-sidebar {
+  display: flex;
+  flex-direction: column;
+
+  width: 260px;
+  min-height: 400px;
+
+  padding: 20px 12px;
+
+  font-family: inherit;
+  transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+/* Collapsed state — icon-only mode */
+.uiverse-sidebar--collapsed {
+  width: 68px;
+}
+
+/* ================= VARIANT: DEFAULT ================= */
+.uiverse-sidebar--default {
+  background: rgba(15, 17, 24, 0.92);
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+}
+
+.uiverse-sidebar--default .uiverse-sidebar-brand {
+  color: #f1f5f9;
+}
+
+.uiverse-sidebar--default .uiverse-sidebar-section-title {
+  color: #64748b;
+}
+
+.uiverse-sidebar--default .uiverse-sidebar-item {
+  color: #94a3b8;
+}
+
+.uiverse-sidebar--default .uiverse-sidebar-item:hover {
+  color: #e2e8f0;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.uiverse-sidebar--default .uiverse-sidebar-item--active {
+  color: #fff;
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.uiverse-sidebar--default .uiverse-sidebar-item--active .uiverse-sidebar-item-icon {
+  color: #818cf8;
+}
+
+/* ================= VARIANT: MINIMAL ================= */
+.uiverse-sidebar--minimal {
+  background: transparent;
+  border-right: none;
+  border-radius: 0;
+}
+
+.uiverse-sidebar--minimal .uiverse-sidebar-brand {
+  color: #e2e8f0;
+}
+
+.uiverse-sidebar--minimal .uiverse-sidebar-section-title {
+  color: #475569;
+}
+
+.uiverse-sidebar--minimal .uiverse-sidebar-item {
+  color: #94a3b8;
+  border-radius: 8px;
+}
+
+.uiverse-sidebar--minimal .uiverse-sidebar-item:hover {
+  color: #e2e8f0;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.uiverse-sidebar--minimal .uiverse-sidebar-item--active {
+  color: #c7d2fe;
+  background: none;
+}
+
+.uiverse-sidebar--minimal .uiverse-sidebar-item--active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 20px;
+  border-radius: 0 4px 4px 0;
+  background: #6366f1;
+}
+
+/* ================= VARIANT: BORDERED ================= */
+.uiverse-sidebar--bordered {
+  background: rgba(15, 17, 24, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.uiverse-sidebar--bordered .uiverse-sidebar-brand {
+  color: #f1f5f9;
+}
+
+.uiverse-sidebar--bordered .uiverse-sidebar-section-title {
+  color: #64748b;
+}
+
+.uiverse-sidebar--bordered .uiverse-sidebar-item {
+  color: #94a3b8;
+  border: 1px solid transparent;
+}
+
+.uiverse-sidebar--bordered .uiverse-sidebar-item:hover {
+  color: #e2e8f0;
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.uiverse-sidebar--bordered .uiverse-sidebar-item--active {
+  color: #e0e7ff;
+  background: rgba(99, 102, 241, 0.12);
+  border-color: rgba(99, 102, 241, 0.25);
+}
+
+.uiverse-sidebar--bordered .uiverse-sidebar-item--active .uiverse-sidebar-item-icon {
+  color: #a5b4fc;
+}
+
+/* ================= VARIANT: GRADIENT ================= */
+.uiverse-sidebar--gradient {
+  background: linear-gradient(180deg, #1e1b4b 0%, #312e81 50%, #3730a3 100%);
+  border-right: none;
+  border-radius: 16px;
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-brand {
+  color: #e0e7ff;
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-section-title {
+  color: #a5b4fc;
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-item {
+  color: rgba(224, 231, 255, 0.7);
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-item:hover {
+  color: #e0e7ff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-item--active {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-item--active .uiverse-sidebar-item-icon {
+  color: #c7d2fe;
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-separator {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-collapse-btn {
+  color: rgba(224, 231, 255, 0.7);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.uiverse-sidebar--gradient .uiverse-sidebar-collapse-btn:hover {
+  color: #e0e7ff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* ================= HEADER / BRAND ================= */
+.uiverse-sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  padding: 8px 12px 20px;
+  margin-bottom: 4px;
+
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.uiverse-sidebar-header svg {
+  flex-shrink: 0;
+  opacity: 0.8;
+  color: inherit;
+}
+
+.uiverse-sidebar-brand {
+  font-size: 1.1rem;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+/* ================= NAVIGATION ================= */
+.uiverse-sidebar-nav {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+
+/* ── Section ── */
+.uiverse-sidebar-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.uiverse-sidebar-section+.uiverse-sidebar-section {
+  margin-top: 16px;
+}
+
+.uiverse-sidebar-section-title {
+  padding: 0 12px;
+  margin: 0 0 8px;
+
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* ── Separator (collapsed mode) ── */
+.uiverse-sidebar-separator {
+  height: 1px;
+  margin: 8px 12px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* ── Item ── */
+.uiverse-sidebar-item {
+  position: relative;
+
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  padding: 10px 12px;
+  border-radius: 10px;
+
+  font-size: 0.88rem;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.uiverse-sidebar-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  width: 20px;
+  height: 20px;
+
+  transition: color 0.2s ease;
+}
+
+.uiverse-sidebar-item-label {
+  opacity: 1;
+  transition: opacity 0.2s ease;
+}
+
+/* ================= COLLAPSE BUTTON ================= */
+.uiverse-sidebar-collapse-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+
+  margin-top: auto;
+  padding: 10px 12px;
+
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 10px;
+
+  background: none;
+  color: #64748b;
+
+  font-size: 0.82rem;
+  font-weight: 500;
+  font-family: inherit;
+
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+}
+
+.uiverse-sidebar-collapse-btn:hover {
+  color: #e2e8f0;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.uiverse-sidebar-collapse-btn svg {
+  flex-shrink: 0;
+}
+
+/* ================= COLLAPSED ADJUSTMENTS ================= */
+.uiverse-sidebar--collapsed .uiverse-sidebar-header {
+  justify-content: center;
+  padding: 8px 0 20px;
+}
+
+.uiverse-sidebar--collapsed .uiverse-sidebar-item {
+  justify-content: center;
+  padding: 10px;
+}
+
+.uiverse-sidebar--collapsed .uiverse-sidebar-collapse-btn {
+  justify-content: center;
+  padding: 10px;
+}
+
+/* ================= SCROLLBAR ================= */
+.uiverse-sidebar-nav::-webkit-scrollbar {
+  width: 4px;
+}
+
+.uiverse-sidebar-nav::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.uiverse-sidebar-nav::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 99px;
+}
+
+.uiverse-sidebar-nav::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
+}

--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -1,0 +1,230 @@
+// Sidebar.jsx – Reusable Sidebar Navigation component
+
+
+import React, { useState } from 'react'
+import './Sidebar.css'
+
+
+
+const IconMap = {
+  dashboard: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="3" width="7" height="7" rx="1" />
+      <rect x="14" y="3" width="7" height="7" rx="1" />
+      <rect x="3" y="14" width="7" height="7" rx="1" />
+      <rect x="14" y="14" width="7" height="7" rx="1" />
+    </svg>
+  ),
+  analytics: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="18" y1="20" x2="18" y2="10" />
+      <line x1="12" y1="20" x2="12" y2="4" />
+      <line x1="6" y1="20" x2="6" y2="14" />
+    </svg>
+  ),
+  users: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  ),
+  settings: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  ),
+  inbox: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+      <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+    </svg>
+  ),
+  calendar: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  ),
+  folder: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+    </svg>
+  ),
+  bookmark: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+    </svg>
+  ),
+  search: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </svg>
+  ),
+  home: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+      <polyline points="9 22 9 12 15 12 15 22" />
+    </svg>
+  ),
+  star: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+    </svg>
+  ),
+  bell: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  ),
+}
+
+// Collapse toggle icons
+const CollapseIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <polyline points="11 17 6 12 11 7" />
+    <polyline points="18 17 13 12 18 7" />
+  </svg>
+)
+
+const ExpandIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <polyline points="13 17 18 12 13 7" />
+    <polyline points="6 17 11 12 6 7" />
+  </svg>
+)
+
+// Default brand icon
+const BrandIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+    <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5" />
+  </svg>
+)
+
+/* ================= COMPONENT ================= */
+
+function Sidebar({
+  brand = 'AppName',
+  sections = [
+    {
+      title: 'Main',
+      items: [
+        { label: 'Dashboard', href: '#', icon: 'dashboard' },
+        { label: 'Analytics', href: '#', icon: 'analytics' },
+        { label: 'Users', href: '#', icon: 'users' },
+      ],
+    },
+    {
+      title: 'Other',
+      items: [
+        { label: 'Settings', href: '#', icon: 'settings' },
+        { label: 'Inbox', href: '#', icon: 'inbox' },
+      ],
+    },
+  ],
+  variant = 'default',
+  collapsible = false,
+  defaultCollapsed = false,
+  activeItem = 'Dashboard',
+  onItemClick = null,
+}) {
+  // Track which item is currently active (controlled or uncontrolled)
+  const [currentActive, setCurrentActive] = useState(activeItem)
+
+  // Track collapsed state (only relevant when collapsible=true)
+  const [collapsed, setCollapsed] = useState(defaultCollapsed)
+
+  // Handle click on a nav item
+  const handleClick = (item) => {
+    setCurrentActive(item.label)
+    if (onItemClick) onItemClick(item)
+  }
+
+  // Build CSS class list
+  const sidebarClasses = [
+    'uiverse-sidebar',
+    `uiverse-sidebar--${variant}`,
+    collapsed ? 'uiverse-sidebar--collapsed' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <aside className={sidebarClasses}>
+
+      {/* ── Brand header ── */}
+      <div className="uiverse-sidebar-header">
+        <BrandIcon />
+        {!collapsed && (
+          <span className="uiverse-sidebar-brand">{brand}</span>
+        )}
+      </div>
+
+      {/* ── Navigation sections ── */}
+      <nav className="uiverse-sidebar-nav">
+        {sections.map((section, si) => (
+          <div className="uiverse-sidebar-section" key={si}>
+            {/* Section title (hidden when collapsed) */}
+            {section.title && !collapsed && (
+              <p className="uiverse-sidebar-section-title">{section.title}</p>
+            )}
+
+            {/* Section separator when collapsed (just a thin line) */}
+            {section.title && collapsed && si > 0 && (
+              <div className="uiverse-sidebar-separator" />
+            )}
+
+            {/* Items */}
+            {section.items.map((item, ii) => {
+              const isActive = currentActive === item.label
+              return (
+                <a
+                  key={ii}
+                  href={item.href}
+                  className={`uiverse-sidebar-item ${isActive ? 'uiverse-sidebar-item--active' : ''}`}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    handleClick(item)
+                  }}
+                  title={collapsed ? item.label : undefined}
+                >
+                  {/* Icon */}
+                  <span className="uiverse-sidebar-item-icon">
+                    {IconMap[item.icon] || IconMap.home}
+                  </span>
+
+                  {/* Label (hidden when collapsed) */}
+                  {!collapsed && (
+                    <span className="uiverse-sidebar-item-label">
+                      {item.label}
+                    </span>
+                  )}
+                </a>
+              )
+            })}
+          </div>
+        ))}
+      </nav>
+
+      {/* ── Collapse toggle ── */}
+      {collapsible && (
+        <button
+          className="uiverse-sidebar-collapse-btn"
+          onClick={() => setCollapsed(prev => !prev)}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        >
+          {collapsed ? <ExpandIcon /> : <CollapseIcon />}
+          {!collapsed && <span>Collapse</span>}
+        </button>
+      )}
+    </aside>
+  )
+}
+
+export default Sidebar

--- a/src/data/componentsList.js
+++ b/src/data/componentsList.js
@@ -48,8 +48,8 @@ export const componentsList = [
     id: 6,
     name: 'Navbar',
     category: 'Navigation',
-    status: 'Planned',
-    description: 'Responsive top navigation bar with logo and links.',
+    status: 'Stable',
+    description: 'Responsive navigation bar with brand, links, CTA, and multiple variant styles.',
   },
 
 
@@ -61,5 +61,15 @@ export const componentsList = [
     status: 'Stable',
     description:
       'Reusable alert component for success, error, warning, and informational messages.',
+  },
+
+  // Sidebar navigation component
+  {
+    id: 8,
+    name: 'Sidebar',
+    category: 'Navigation',
+    status: 'Stable',
+    description:
+      'Vertical sidebar navigation with sections, icons, variants, and collapsible mode.',
   },
 ]

--- a/src/layout/AppNavbar/AppNavbar.css
+++ b/src/layout/AppNavbar/AppNavbar.css
@@ -1,0 +1,254 @@
+:root {
+  --app-nav-text: #e5e7eb;
+  --app-nav-muted: #9ca3af;
+  --app-nav-primary: #4f46e5;
+  --app-nav-primary-light: #6366f1;
+  --app-nav-hover: rgba(255, 255, 255, 0.06);
+
+  --app-surface: rgba(31, 34, 44, 0.85);
+  --app-border: rgba(255, 255, 255, 0.08);
+}
+
+/* ================= NAVBAR ================= */
+.app-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 0 32px;
+  height: 64px;
+
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+
+  background: var(--app-surface);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+
+  border-bottom: 1px solid var(--app-border);
+
+  transition: all 0.3s ease;
+}
+
+.app-navbar--scrolled {
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
+}
+
+/* ================= LOGO ================= */
+.app-navbar-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  text-decoration: none;
+  font-size: 1.2rem;
+  font-weight: 800;
+  letter-spacing: -0.5px;
+  color: white;
+
+  transition: transform 0.2s ease;
+}
+
+.app-navbar-logo:hover {
+  transform: translateY(-1px);
+}
+
+/* ================= LINKS ================= */
+.app-navbar-links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-navbar-link {
+  position: relative;
+  padding: 10px 16px;
+  border-radius: 10px;
+
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--app-nav-muted);
+  text-decoration: none;
+
+  transition: all 0.25s ease;
+}
+
+.app-navbar-link:hover {
+  color: white;
+  background: var(--app-nav-hover);
+  transform: translateY(-1px);
+}
+
+/* Active Link */
+.app-navbar-link.active {
+  color: white;
+  background: rgba(99, 102, 241, 0.15);
+}
+
+/* Underline animation */
+.app-navbar-link::after {
+  content: "";
+  position: absolute;
+  left: 16px;
+  bottom: 6px;
+  width: 0%;
+  height: 2px;
+  background: var(--app-nav-primary-light);
+  border-radius: 999px;
+  transition: width 0.25s ease;
+}
+
+.app-navbar-link:hover::after,
+.app-navbar-link.active::after {
+  width: calc(100% - 32px);
+}
+
+/* ================= GITHUB BUTTON ================= */
+.app-navbar-github {
+  margin-left: 8px;
+
+  background: linear-gradient(135deg,
+      var(--app-nav-primary),
+      var(--app-nav-primary-light));
+
+  color: white !important;
+  font-weight: 600;
+  padding: 10px 16px;
+  border-radius: 12px;
+
+  box-shadow: 0 6px 18px rgba(79, 70, 229, 0.28);
+
+  transition: all 0.25s ease;
+}
+
+.app-navbar-github:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(5, 1, 75, 0.4);
+}
+
+/* ================= THEME TOGGLE ================= */
+.app-theme-toggle {
+  margin-left: 8px;
+
+  width: 36px;
+  height: 36px;
+
+  border-radius: 10px;
+  border: 1px solid var(--app-border);
+
+  background: rgba(255, 255, 255, 0.04);
+  color: white;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  cursor: pointer;
+
+  transition: all 0.2s ease;
+}
+
+.app-theme-toggle:hover {
+  background: rgba(99, 102, 241, 0.15);
+  transform: rotate(15deg) scale(1.05);
+}
+
+.app-theme-toggle:active {
+  transform: rotate(180deg) scale(0.9);
+}
+
+/* ================= MOBILE BUTTON ================= */
+.app-nav-btn {
+  display: none;
+
+  width: 42px;
+  height: 42px;
+
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 10px;
+  border: 1px solid var(--app-border);
+
+  background: rgba(255, 255, 255, 0.04);
+  color: white;
+
+  font-size: 1.3rem;
+  cursor: pointer;
+
+  transition: all 0.2s ease;
+}
+
+.app-nav-btn:hover {
+  background: rgba(99, 102, 241, 0.15);
+  transform: scale(1.05);
+}
+
+/* ================= MOBILE STYLES ================= */
+@media (max-width: 768px) {
+  .app-navbar {
+    padding: 0 20px;
+    height: 68px;
+  }
+
+  .app-nav-btn {
+    display: flex;
+  }
+
+  .app-navbar-links {
+    position: absolute;
+    top: 80px;
+    right: 20px;
+
+    width: 230px;
+
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+
+    gap: 8px;
+    padding: 18px;
+
+    background: rgba(39, 43, 54, 0.96);
+
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+
+    border: 1px solid var(--app-border);
+    border-radius: 16px;
+
+    box-shadow:
+      0 20px 40px rgba(0, 0, 0, 0.45),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+
+    animation: appMenuFade 0.25s ease;
+  }
+
+  .app-navbar-links.active {
+    display: flex;
+  }
+
+  .app-navbar-link {
+    width: 100%;
+    padding: 12px 14px;
+  }
+
+  .app-navbar-github {
+    margin-top: 6px;
+    text-align: center;
+  }
+}
+
+/* ================= ANIMATION ================= */
+@keyframes appMenuFade {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/layout/AppNavbar/AppNavbar.jsx
+++ b/src/layout/AppNavbar/AppNavbar.jsx
@@ -1,0 +1,149 @@
+// AppNavbar.jsx – Application-level navigation bar (NOT a reusable component)
+
+
+import React, { useState, useEffect } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import './AppNavbar.css'
+
+/* ================= ICONS ================= */
+
+// Hamburger menu icon (replaces FaBars from react-icons)
+const BarsIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+)
+
+// Close / X icon (replaces FaTimes from react-icons)
+const TimesIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+)
+
+const SunIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="5" />
+    <line x1="12" y1="1" x2="12" y2="3" />
+    <line x1="12" y1="21" x2="12" y2="23" />
+  </svg>
+)
+
+const MoonIcon = () => (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3" />
+  </svg>
+)
+
+const LogoIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="url(#logo-grad)" strokeWidth="1.8">
+    <defs>
+      <linearGradient id="logo-grad">
+        <stop offset="0%" stopColor="#4f46e5" />
+        <stop offset="100%" stopColor="#a855f7" />
+      </linearGradient>
+    </defs>
+    <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5" />
+  </svg>
+)
+
+/* ================= COMPONENT ================= */
+
+function AppNavbar() {
+  const location = useLocation()
+
+  const [scrolled, setScrolled] = useState(false)
+  const [isOpen, setIsOpen] = useState(false)
+
+  // Theme state
+  const [dark, setDark] = useState(() => {
+    const saved = localStorage.getItem('uiverse-theme')
+    if (saved) return saved === 'dark'
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  })
+
+  /* ================= EFFECTS ================= */
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light')
+    localStorage.setItem('uiverse-theme', dark ? 'dark' : 'light')
+  }, [dark])
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 10)
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  /* ================= HANDLERS ================= */
+
+  const toggleTheme = () => {
+    setDark(prev => !prev)
+  }
+
+  const handleOpenNavbar = () => {
+    setIsOpen(prev => !prev)
+  }
+
+  const closeMenu = () => {
+    setIsOpen(false)
+  }
+
+  /* ================= JSX ================= */
+
+  return (
+    <nav className={`app-navbar ${scrolled ? 'app-navbar--scrolled' : ''}`}>
+
+      {/* LOGO */}
+      <Link to="/" className="app-navbar-logo" onClick={closeMenu}>
+        <LogoIcon />
+        UIverse
+      </Link>
+
+      {/* LINKS */}
+      <div className={`app-navbar-links ${isOpen ? "active" : ""}`}>
+
+        <Link to="/" onClick={closeMenu}
+          className={`app-navbar-link ${location.pathname === '/' ? 'active' : ''}`}>
+          Home
+        </Link>
+
+        <Link to="/components" onClick={closeMenu}
+          className={`app-navbar-link ${location.pathname === '/components' ? 'active' : ''}`}>
+          Components
+        </Link>
+        {/* Get Started CTA (links to docs page) */}
+        <Link
+          to="/docs"
+          className="app-navbar-link app-navbar-github"
+          onClick={closeMenu}
+        >
+          Get Started
+        </Link>
+
+        {/* Theme Toggle */}
+        <button
+          className="app-theme-toggle"
+          onClick={toggleTheme}
+        >
+          {dark ? <SunIcon /> : <MoonIcon />}
+        </button>
+
+      </div>
+
+      {/* MOBILE BUTTON */}
+      <button
+        onClick={handleOpenNavbar}
+        className="app-nav-btn"
+      >
+        {isOpen ? <TimesIcon /> : <BarsIcon />}
+      </button>
+
+    </nav>
+  )
+}
+
+export default AppNavbar

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -1,9 +1,11 @@
 // Components.jsx – Component showcase page
 import React, { useState } from 'react'
 import Button from '../components/Button/Button.jsx'
+import AppNavbar from '../layout/AppNavbar/AppNavbar.jsx'
 import Navbar from '../components/Navbar/Navbar.jsx'
 import Badge from '../components/Badge/Badge.jsx'
 import Alert from '../components/Alert/Alert'
+import Sidebar from '../components/Sidebar/Sidebar.jsx'
 import { componentsList } from '../data/componentsList.js'
 import './Components.css'
 
@@ -15,7 +17,7 @@ const sections = [
     label: 'Buttons',
     icon: (
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <rect x="3" y="8" width="18" height="8" rx="3"/>
+        <rect x="3" y="8" width="18" height="8" rx="3" />
       </svg>
     ),
   },
@@ -24,30 +26,53 @@ const sections = [
     label: 'Badges',
     icon: (
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M12 2l4 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L1 9h7z"/>
+        <path d="M12 2l4 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L1 9h7z" />
       </svg>
     ),
   },
   {
-  id: 'alerts',
-  label: 'Alerts',
-  icon: (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M10 2L2 22h20L14 2z"/>
-    </svg>
-  ),
-},
+    id: 'alerts',
+    label: 'Alerts',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M10 2L2 22h20L14 2z" />
+      </svg>
+    ),
+  },
+  {
+    id: 'navbars',
+    label: 'Navbars',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <rect x="2" y="4" width="20" height="5" rx="1.5" />
+        <line x1="6" y1="6.5" x2="10" y2="6.5" />
+        <circle cx="18" cy="6.5" r="1" />
+      </svg>
+    ),
+  },
+  {
+    id: 'sidebars',
+    label: 'Sidebars',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <rect x="3" y="3" width="7" height="18" rx="1.5" />
+        <line x1="14" y1="8" x2="21" y2="8" />
+        <line x1="14" y1="12" x2="21" y2="12" />
+        <line x1="14" y1="16" x2="19" y2="16" />
+      </svg>
+    ),
+  },
   {
     id: 'all-components',
     label: 'All Components',
     icon: (
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <line x1="8" y1="6" x2="21" y2="6"/>
-        <line x1="8" y1="12" x2="21" y2="12"/>
-        <line x1="8" y1="18" x2="21" y2="18"/>
-        <line x1="3" y1="6" x2="3.01" y2="6"/>
-        <line x1="3" y1="12" x2="3.01" y2="12"/>
-        <line x1="3" y1="18" x2="3.01" y2="18"/>
+        <line x1="8" y1="6" x2="21" y2="6" />
+        <line x1="8" y1="12" x2="21" y2="12" />
+        <line x1="8" y1="18" x2="21" y2="18" />
+        <line x1="3" y1="6" x2="3.01" y2="6" />
+        <line x1="3" y1="12" x2="3.01" y2="12" />
+        <line x1="3" y1="18" x2="3.01" y2="18" />
       </svg>
     ),
   },
@@ -56,14 +81,14 @@ const sections = [
 
 const CopyIcon = () => (
   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <rect x="9" y="9" width="13" height="13" rx="2"/>
-    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+    <rect x="9" y="9" width="13" height="13" rx="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
   </svg>
 )
 
 const CheckIcon = () => (
   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
-    <polyline points="20 6 9 17 4 12"/>
+    <polyline points="20 6 9 17 4 12" />
   </svg>
 )
 
@@ -72,6 +97,227 @@ const CheckIcon = () => (
 function Components() {
   const [activeSection, setActiveSection] = useState('buttons')
   const [copied, setCopied] = useState(false)
+
+  // Track which navbar variant is selected for the code preview
+  const [selectedNavbar, setSelectedNavbar] = useState(0)
+
+  // Track which sidebar variant is selected for the code preview
+  const [selectedSidebar, setSelectedSidebar] = useState(0)
+
+  // All navbar variant configurations — preview + code stay in sync
+  const navbarVariants = [
+    {
+      brand: 'MyApp',
+      links: [
+        { label: 'Home', href: '#' },
+        { label: 'Features', href: '#' },
+        { label: 'Pricing', href: '#' },
+      ],
+      variant: 'default',
+      cta: { label: 'Sign Up', href: '#' },
+      code: `<Navbar
+  brand="MyApp"
+  links={[
+    { label: 'Home', href: '/' },
+    { label: 'Features', href: '/features' },
+    { label: 'Pricing', href: '/pricing' },
+  ]}
+  variant="default"
+  sticky={true}
+  cta={{ label: 'Sign Up', href: '/signup' }}
+/>`,
+    },
+    {
+      brand: 'Studio',
+      links: [
+        { label: 'Work', href: '#' },
+        { label: 'About', href: '#' },
+        { label: 'Blog', href: '#' },
+      ],
+      variant: 'solid',
+      cta: null,
+      code: `<Navbar
+  brand="Studio"
+  links={[
+    { label: 'Work', href: '/work' },
+    { label: 'About', href: '/about' },
+    { label: 'Blog', href: '/blog' },
+  ]}
+  variant="solid"
+  sticky={true}
+/>`,
+    },
+    {
+      brand: 'Starter',
+      links: [
+        { label: 'Docs', href: '#' },
+        { label: 'Components', href: '#' },
+        { label: 'GitHub', href: '#' },
+      ],
+      variant: 'gradient',
+      cta: { label: 'Get Started', href: '#' },
+      code: `<Navbar
+  brand="Starter"
+  links={[
+    { label: 'Docs', href: '/docs' },
+    { label: 'Components', href: '/components' },
+    { label: 'GitHub', href: '/github' },
+  ]}
+  variant="gradient"
+  sticky={true}
+  cta={{ label: 'Get Started', href: '/get-started' }}
+/>`,
+    },
+    {
+      brand: 'Portfolio',
+      links: [
+        { label: 'Projects', href: '#' },
+        { label: 'Resume', href: '#' },
+        { label: 'Contact', href: '#' },
+      ],
+      variant: 'transparent',
+      cta: null,
+      code: `<Navbar
+  brand="Portfolio"
+  links={[
+    { label: 'Projects', href: '/projects' },
+    { label: 'Resume', href: '/resume' },
+    { label: 'Contact', href: '/contact' },
+  ]}
+  variant="transparent"
+  sticky={true}
+/>`,
+    },
+  ]
+
+  // All sidebar variant configurations — preview + code stay in sync
+  const sidebarVariants = [
+    {
+      brand: 'Dashboard',
+      variant: 'default',
+      activeItem: 'Analytics',
+      sections: [
+        {
+          title: 'Main',
+          items: [
+            { label: 'Dashboard', href: '#', icon: 'dashboard' },
+            { label: 'Analytics', href: '#', icon: 'analytics' },
+            { label: 'Users', href: '#', icon: 'users' },
+          ],
+        },
+        {
+          title: 'Other',
+          items: [
+            { label: 'Settings', href: '#', icon: 'settings' },
+            { label: 'Inbox', href: '#', icon: 'inbox' },
+          ],
+        },
+      ],
+      code: `<Sidebar
+  brand="Dashboard"
+  variant="default"
+  activeItem="Analytics"
+  sections={[
+    {
+      title: 'Main',
+      items: [
+        { label: 'Dashboard', href: '/', icon: 'dashboard' },
+        { label: 'Analytics', href: '/analytics', icon: 'analytics' },
+        { label: 'Users', href: '/users', icon: 'users' },
+      ],
+    },
+    {
+      title: 'Other',
+      items: [
+        { label: 'Settings', href: '/settings', icon: 'settings' },
+        { label: 'Inbox', href: '/inbox', icon: 'inbox' },
+      ],
+    },
+  ]}
+  onItemClick={(item) => console.log(item)}
+/>`,
+    },
+    {
+      brand: 'Studio',
+      variant: 'gradient',
+      activeItem: 'Bookmarks',
+      sections: [
+        {
+          title: 'Workspace',
+          items: [
+            { label: 'Home', href: '#', icon: 'home' },
+            { label: 'Bookmarks', href: '#', icon: 'bookmark' },
+            { label: 'Search', href: '#', icon: 'search' },
+          ],
+        },
+        {
+          title: 'Manage',
+          items: [
+            { label: 'Calendar', href: '#', icon: 'calendar' },
+            { label: 'Folders', href: '#', icon: 'folder' },
+          ],
+        },
+      ],
+      code: `<Sidebar
+  brand="Studio"
+  variant="gradient"
+  activeItem="Bookmarks"
+  sections={[
+    {
+      title: 'Workspace',
+      items: [
+        { label: 'Home', href: '/', icon: 'home' },
+        { label: 'Bookmarks', href: '/bookmarks', icon: 'bookmark' },
+        { label: 'Search', href: '/search', icon: 'search' },
+      ],
+    },
+    {
+      title: 'Manage',
+      items: [
+        { label: 'Calendar', href: '/calendar', icon: 'calendar' },
+        { label: 'Folders', href: '/folders', icon: 'folder' },
+      ],
+    },
+  ]}
+  onItemClick={(item) => console.log(item)}
+/>`,
+    },
+    {
+      brand: 'MyApp',
+      variant: 'bordered',
+      activeItem: 'Dashboard',
+      collapsible: true,
+      sections: [
+        {
+          title: 'Navigation',
+          items: [
+            { label: 'Dashboard', href: '#', icon: 'dashboard' },
+            { label: 'Analytics', href: '#', icon: 'analytics' },
+            { label: 'Notifications', href: '#', icon: 'bell' },
+            { label: 'Favorites', href: '#', icon: 'star' },
+          ],
+        },
+      ],
+      code: `<Sidebar
+  brand="MyApp"
+  variant="bordered"
+  activeItem="Dashboard"
+  collapsible={true}
+  sections={[
+    {
+      title: 'Navigation',
+      items: [
+        { label: 'Dashboard', href: '/', icon: 'dashboard' },
+        { label: 'Analytics', href: '/analytics', icon: 'analytics' },
+        { label: 'Notifications', href: '/notifications', icon: 'bell' },
+        { label: 'Favorites', href: '/favorites', icon: 'star' },
+      ],
+    },
+  ]}
+  onItemClick={(item) => console.log(item)}
+/>`,
+    },
+  ]
 
   const handleCopy = (code) => {
     navigator.clipboard.writeText(code)
@@ -89,7 +335,7 @@ function Components() {
 
   return (
     <div className="comp-page">
-      <Navbar />
+      <AppNavbar />
 
       <div className="comp-layout">
 
@@ -120,7 +366,7 @@ function Components() {
           >
             <span className="sidebar-item-icon">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
+                <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
               </svg>
             </span>
             GitHub Repo
@@ -196,126 +442,427 @@ function Components() {
 
 
           {/* ── Alert Section ── */}
-<section className="comp-section" id="alerts">
-  <div className="comp-section-header">
-    <h2>Alert</h2>
-    <span className="comp-badge comp-badge--stable">
-      Stable
-    </span>
-  </div>
+          <section className="comp-section" id="alerts">
+            <div className="comp-section-header">
+              <h2>Alert</h2>
+              <span className="comp-badge comp-badge--stable">
+                Stable
+              </span>
+            </div>
 
-  <p className="comp-section-desc">
-    Reusable alert component with multiple variants
-    for success, error, warning, and informational
-    messages.
-  </p>
+            <p className="comp-section-desc">
+              Reusable alert component with multiple variants
+              for success, error, warning, and informational
+              messages.
+            </p>
 
-  {/* Variants */}
-  <div className="comp-subsection">
-    <h3 className="comp-subsection-title">
-      Variants
-    </h3>
+            {/* Variants */}
+            <div className="comp-subsection">
+              <h3 className="comp-subsection-title">
+                Variants
+              </h3>
 
-    <div className="comp-preview">
-      <Alert
-        type="success"
-        message="Action completed successfully!"
-      />
+              <div className="comp-preview">
+                <Alert
+                  type="success"
+                  message="Action completed successfully!"
+                />
 
-      <Alert
-        type="error"
-        message="Something went wrong."
-      />
+                <Alert
+                  type="error"
+                  message="Something went wrong."
+                />
 
-      <Alert
-        type="warning"
-        message="Warning message here."
-      />
+                <Alert
+                  type="warning"
+                  message="Warning message here."
+                />
 
-      <Alert
-        type="info"
-        message="Information message."
-      />
+                <Alert
+                  type="info"
+                  message="Information message."
+                />
 
-      <Alert
-    type="info"
-    message="Closable alert example."
-    closable
-      />
-    </div>
-  </div>
+                <Alert
+                  type="info"
+                  message="Closable alert example."
+                  closable
+                />
+              </div>
+            </div>
 
-  {/* Code Block */}
-  <div className="code-block">
-    <div className="code-block-header">
-      <span>JSX</span>
+            {/* Code Block */}
+            <div className="code-block">
+              <div className="code-block-header">
+                <span>JSX</span>
 
-      <button
-        className="copy-btn"
-        onClick={() =>
-          handleCopy(`<Alert type="success" message="Action completed successfully!" />
+                <button
+                  className="copy-btn"
+                  onClick={() =>
+                    handleCopy(`<Alert type="success" message="Action completed successfully!" />
 <Alert type="error" message="Something went wrong." />
 <Alert type="warning" message="Warning message here." />
 <Alert type="info" message="Information message." />
 <Alert type="info" message="Closable alert example." closable />`)
-        }
-      >
-        {copied ? '✅ Copied!' : '📋 Copy'}
-      </button>
-    </div>
+                  }
+                >
+                  {copied ? '✅ Copied!' : '📋 Copy'}
+                </button>
+              </div>
 
-    <pre>{`<Alert type="success" message="Action completed successfully!" />
+              <pre>{`<Alert type="success" message="Action completed successfully!" />
 <Alert type="error" message="Something went wrong." />
 <Alert type="warning" message="Warning message here." />
 <Alert type="info" message="Information message." />
 <Alert type="info" message="Closable alert example." closable />`}</pre>
-  </div>
+            </div>
 
-  {/* Props Table */}
-  <div className="comp-subsection">
-    <h3 className="comp-subsection-title">Props</h3>
+            {/* Props Table */}
+            <div className="comp-subsection">
+              <h3 className="comp-subsection-title">Props</h3>
 
-    <div className="props-table-wrap">
-      <table className="props-table">
-        <thead>
-          <tr>
-            <th>Prop</th>
-            <th>Type</th>
-            <th>Default</th>
-            <th>Description</th>
-          </tr>
-        </thead>
+              <div className="props-table-wrap">
+                <table className="props-table">
+                  <thead>
+                    <tr>
+                      <th>Prop</th>
+                      <th>Type</th>
+                      <th>Default</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
 
-        <tbody>
-          <tr>
-            <td><code>type</code></td>
-            <td>string</td>
-            <td><code>"info"</code></td>
-            <td>
-              success · error · warning · info
-            </td>
-          </tr>
+                  <tbody>
+                    <tr>
+                      <td><code>type</code></td>
+                      <td>string</td>
+                      <td><code>"info"</code></td>
+                      <td>
+                        success · error · warning · info
+                      </td>
+                    </tr>
 
-          <tr>
-            <td><code>message</code></td>
-            <td>string</td>
-            <td>
-              <code>"This is an alert"</code>
-            </td>
-            <td>Alert message text</td>
-          </tr>
+                    <tr>
+                      <td><code>message</code></td>
+                      <td>string</td>
+                      <td>
+                        <code>"This is an alert"</code>
+                      </td>
+                      <td>Alert message text</td>
+                    </tr>
 
-          <tr>
-            <td><code>closable</code></td>
-            <td>boolean</td>
-            <td><code>false</code></td>
-            <td>Shows close button</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</section>
+                    <tr>
+                      <td><code>closable</code></td>
+                      <td>boolean</td>
+                      <td><code>false</code></td>
+                      <td>Shows close button</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+
+          {/* ================= NAVBARS ================= */}
+          <section className="comp-section" id="navbars">
+            <div className="comp-section-header">
+              <h2>Navbar</h2>
+              <span className="comp-badge comp-badge--stable">Stable</span>
+            </div>
+
+            <p className="comp-section-desc">
+              Responsive navigation bar with multiple variants, configurable
+              brand, links, and an optional CTA button.
+            </p>
+
+            {/* Variants */}
+            <div className="comp-subsection">
+              <h3 className="comp-subsection-title">Variants</h3>
+              <p className="comp-section-desc" style={{ marginBottom: '12px', fontSize: '0.82rem', opacity: 0.7 }}>
+                Click a navbar to see its code below.
+              </p>
+
+              <div className="comp-preview" style={{ flexDirection: 'column', gap: '16px', padding: '0' }}>
+                {navbarVariants.map((nv, i) => (
+                  <div
+                    key={i}
+                    onClick={() => setSelectedNavbar(i)}
+                    style={{
+                      cursor: 'pointer',
+                      borderRadius: '12px',
+                      outline: selectedNavbar === i
+                        ? '2px solid rgba(99, 102, 241, 0.6)'
+                        : '2px solid transparent',
+                      transition: 'outline 0.2s ease',
+                    }}
+                  >
+                    <Navbar
+                      brand={nv.brand}
+                      links={nv.links}
+                      variant={nv.variant}
+                      sticky={false}
+                      cta={nv.cta}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Code Block — updates dynamically based on selected variant */}
+            <div className="code-block">
+              <div className="code-block-header">
+                <span>JSX · {navbarVariants[selectedNavbar].variant}</span>
+
+                <button
+                  className="copy-btn"
+                  onClick={() => handleCopy(navbarVariants[selectedNavbar].code)}
+                >
+                  {copied ? (
+                    <>
+                      <CheckIcon /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <CopyIcon /> Copy
+                    </>
+                  )}
+                </button>
+              </div>
+
+              <pre>{navbarVariants[selectedNavbar].code}</pre>
+            </div>
+
+            {/* Props Table */}
+            <div className="comp-subsection">
+              <h3 className="comp-subsection-title">Props</h3>
+
+              <div className="props-table-wrap">
+                <table className="props-table">
+                  <thead>
+                    <tr>
+                      <th>Prop</th>
+                      <th>Type</th>
+                      <th>Default</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+
+                  <tbody>
+                    <tr>
+                      <td><code>brand</code></td>
+                      <td>string</td>
+                      <td><code>"Brand"</code></td>
+                      <td>Brand / logo text on the left</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>links</code></td>
+                      <td>array</td>
+                      <td><code>[...]</code></td>
+                      <td>Array of {`{ label, href }`} objects</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>variant</code></td>
+                      <td>string</td>
+                      <td><code>"default"</code></td>
+                      <td>default · transparent · solid · gradient</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>sticky</code></td>
+                      <td>boolean</td>
+                      <td><code>true</code></td>
+                      <td>Stick to top on scroll</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>cta</code></td>
+                      <td>object</td>
+                      <td><code>null</code></td>
+                      <td>Optional CTA: {`{ label, href }`}</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>onLinkClick</code></td>
+                      <td>function</td>
+                      <td><code>null</code></td>
+                      <td>Callback when a link is clicked</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+
+          {/* ================= SIDEBARS ================= */}
+          <section className="comp-section" id="sidebars">
+            <div className="comp-section-header">
+              <h2>Sidebar</h2>
+              <span className="comp-badge comp-badge--stable">Stable</span>
+            </div>
+
+            <p className="comp-section-desc">
+              Vertical sidebar navigation with section grouping, built-in icons,
+              multiple style variants, and an optional collapsible mode.
+            </p>
+
+            {/* Variants — click to update code below */}
+            <div className="comp-subsection">
+              <h3 className="comp-subsection-title">Variants</h3>
+              <p className="comp-section-desc" style={{ marginBottom: '12px', fontSize: '0.82rem', opacity: 0.7 }}>
+                Click a sidebar to see its code below.
+              </p>
+
+              <div className="comp-preview" style={{ flexDirection: 'row', flexWrap: 'wrap', gap: '20px', padding: '20px', alignItems: 'flex-start' }}>
+                {sidebarVariants.map((sv, i) => (
+                  <div
+                    key={i}
+                    onClick={() => setSelectedSidebar(i)}
+                    style={{
+                      cursor: 'pointer',
+                      borderRadius: '16px',
+                      outline: selectedSidebar === i
+                        ? '2px solid rgba(99, 102, 241, 0.6)'
+                        : '2px solid transparent',
+                      transition: 'outline 0.2s ease',
+                    }}
+                  >
+                    <Sidebar
+                      brand={sv.brand}
+                      variant={sv.variant}
+                      activeItem={sv.activeItem}
+                      sections={sv.sections}
+                      collapsible={sv.collapsible || false}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Code Block — updates dynamically based on selected sidebar */}
+            <div className="code-block">
+              <div className="code-block-header">
+                <span>JSX · {sidebarVariants[selectedSidebar].variant}</span>
+
+                <button
+                  className="copy-btn"
+                  onClick={() => handleCopy(sidebarVariants[selectedSidebar].code)}
+                >
+                  {copied ? (
+                    <>
+                      <CheckIcon /> Copied
+                    </>
+                  ) : (
+                    <>
+                      <CopyIcon /> Copy
+                    </>
+                  )}
+                </button>
+              </div>
+
+              <pre>{sidebarVariants[selectedSidebar].code}</pre>
+            </div>
+
+            {/* Props Table */}
+            <div className="comp-subsection">
+              <h3 className="comp-subsection-title">Props</h3>
+
+              <div className="props-table-wrap">
+                <table className="props-table">
+                  <thead>
+                    <tr>
+                      <th>Prop</th>
+                      <th>Type</th>
+                      <th>Default</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+
+                  <tbody>
+                    <tr>
+                      <td><code>brand</code></td>
+                      <td>string</td>
+                      <td><code>"AppName"</code></td>
+                      <td>Brand / app name at the top</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>sections</code></td>
+                      <td>array</td>
+                      <td><code>[...]</code></td>
+                      <td>Array of {`{ title, items: [{ label, href, icon }] }`}</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>variant</code></td>
+                      <td>string</td>
+                      <td><code>"default"</code></td>
+                      <td>default · minimal · bordered · gradient</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>collapsible</code></td>
+                      <td>boolean</td>
+                      <td><code>false</code></td>
+                      <td>Show collapse/expand toggle</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>defaultCollapsed</code></td>
+                      <td>boolean</td>
+                      <td><code>false</code></td>
+                      <td>Start collapsed when collapsible</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>activeItem</code></td>
+                      <td>string</td>
+                      <td><code>"Dashboard"</code></td>
+                      <td>Label of the initially active item</td>
+                    </tr>
+
+                    <tr>
+                      <td><code>onItemClick</code></td>
+                      <td>function</td>
+                      <td><code>null</code></td>
+                      <td>Callback when a nav item is clicked</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Icons reference */}
+            <div className="comp-subsection">
+              <h3 className="comp-subsection-title">Built-in Icons</h3>
+
+              <div className="props-table-wrap">
+                <table className="props-table">
+                  <thead>
+                    <tr>
+                      <th>Icon Key</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr><td><code>dashboard</code></td><td>Grid/overview icon</td></tr>
+                    <tr><td><code>analytics</code></td><td>Bar chart icon</td></tr>
+                    <tr><td><code>users</code></td><td>People/team icon</td></tr>
+                    <tr><td><code>settings</code></td><td>Gear/cog icon</td></tr>
+                    <tr><td><code>inbox</code></td><td>Mail inbox icon</td></tr>
+                    <tr><td><code>calendar</code></td><td>Calendar icon</td></tr>
+                    <tr><td><code>folder</code></td><td>Folder icon</td></tr>
+                    <tr><td><code>bookmark</code></td><td>Bookmark icon</td></tr>
+                    <tr><td><code>search</code></td><td>Magnifying glass icon</td></tr>
+                    <tr><td><code>home</code></td><td>Home icon</td></tr>
+                    <tr><td><code>star</code></td><td>Star/favorite icon</td></tr>
+                    <tr><td><code>bell</code></td><td>Notification bell icon</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
 
           {/* ── All Components Table ── */}
 

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -471,7 +471,6 @@ function Components() {
                 {sections.find((s) => s.id === activeSection)?.label ?? 'Components'}
               </span>
             </span>
-            </span>
             <span
               className={`sidebar-mobile-caret ${sidebarOpen ? 'sidebar-mobile-caret--open' : ''}`}
               aria-hidden="true"
@@ -678,6 +677,8 @@ function Components() {
 <Alert type="warning" message="Warning message here." />
 <Alert type="info" message="Information message." />
 <Alert type="info" message="Closable alert example." closable />`}</pre>
+
+            </div>
 
             {/* Props Table */}
             <div className="comp-subsection">
@@ -1020,8 +1021,7 @@ function Components() {
                 </table>
               </div>
             </div>
-            </section>
-              </div>
+          </section>
 
               <div className="comp-subsection">
                 <h3 className="comp-subsection-title">Props</h3>

--- a/src/pages/GettingStarted.jsx
+++ b/src/pages/GettingStarted.jsx
@@ -11,7 +11,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import Button from '../components/Button/Button.jsx'
 import Badge from '../components/Badge/Badge.jsx'
-import Navbar from '../components/Navbar/Navbar.jsx'
+import AppNavbar from '../layout/AppNavbar/AppNavbar.jsx'
 import './Components.css' // shared layout + code-block + table styles
 import './GettingStarted.css'
 
@@ -109,7 +109,7 @@ function GettingStarted() {
 
   return (
     <div className="comp-page">
-      <Navbar />
+      <AppNavbar />
 
       <div className="comp-layout">
         {/* ── Sidebar / table of contents ── */}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import Button from "../components/Button/Button.jsx";
-import Navbar from "../components/Navbar/Navbar.jsx";
+import AppNavbar from "../layout/AppNavbar/AppNavbar.jsx";
 import "./Home.css";
 
 function Home() {
@@ -27,7 +27,7 @@ function Home() {
   };
   return (
     <div className="home-page">
-      <Navbar />
+      <AppNavbar />
 
       {/* ── Hero ── */}
       <section className="hero">


### PR DESCRIPTION
Related Issue
Closes #58 

Summary : 
Adds reusable, prop-driven Navbar and Sidebar Navigation components to the UIverse library, following the project's philosophy of pure React + CSS, zero dependencies, and beginner-friendly code.

New Components : 
1. Navbar (src/components/Navbar/)
Added four different types reuasble react Navbar componets

2. Sidebar (src/components/Sidebar/)
Added three different types reuable  react Sidebar components

This PR also contains one minor structural change 

App-Level Navbar Separation
Problem: The existing src/components/Navbar/Navbar.jsx was not a reusable component, it was the application's own navigation bar.

This violated the project's own philosophy that src/components/ should only contain reusable, prop-driven components (like Button, Badge, Alert). 

what i did?
i created layout folder and inside it i created AppNavbar (both jsx and css) and shifted the Navbar code from src/components to layout/AppNavbar and updated the Navbar as a reasable component.
