### PR TITLE
feat: add scroll progress indicator for docs pages

### DIFF
--- a/src/pages/GettingStarted.css
+++ b/src/pages/GettingStarted.css
@@ -1,6 +1,35 @@
 /* GettingStarted.css – Doc-specific styles
    Layout, sidebar, code blocks and tables are reused from Components.css */
 
+/* ── Scroll progress indicator ── */
+.scroll-progress-track {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  z-index: 1100;
+  background: transparent;
+  pointer-events: none;
+}
+
+.scroll-progress-bar {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, #6366f1, #8b5cf6, #a78bfa);
+  transform-origin: left center;
+  transform: scaleX(0);
+  transition: transform 0.12s ease-out;
+  box-shadow: 0 0 8px rgba(99, 102, 241, 0.5),
+              0 0 2px rgba(139, 92, 246, 0.3);
+}
+
+[data-theme="dark"] .scroll-progress-bar {
+  background: linear-gradient(90deg, #818cf8, #a78bfa, #c4b5fd);
+  box-shadow: 0 0 12px rgba(129, 140, 248, 0.6),
+              0 0 4px rgba(167, 139, 250, 0.4);
+}
+
 /* ── Prose ── */
 .doc-prose {
   font-size: 0.95rem;

--- a/src/pages/GettingStarted.jsx
+++ b/src/pages/GettingStarted.jsx
@@ -51,6 +51,44 @@ function CodeBlock({ label = 'BASH', code }) {
   )
 }
 
+// Scroll progress bar — tracks how far the user has scrolled
+function ScrollProgressBar() {
+  const barRef = useRef(null)
+
+  useEffect(() => {
+    let ticking = false
+
+    const updateProgress = () => {
+      const scrollTop = window.scrollY
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight
+      const progress = docHeight > 0 ? Math.min(scrollTop / docHeight, 1) : 0
+      if (barRef.current) {
+        barRef.current.style.transform = `scaleX(${progress})`
+      }
+      ticking = false
+    }
+
+    const onScroll = () => {
+      if (!ticking) {
+        requestAnimationFrame(updateProgress)
+        ticking = true
+      }
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    // Set initial state
+    updateProgress()
+
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return (
+    <div className="scroll-progress-track" aria-hidden="true">
+      <div className="scroll-progress-bar" ref={barRef} />
+    </div>
+  )
+}
+
 // Labeled note box (replaces emoji callouts)
 function Note({ label = 'Note', children }) {
   return (
@@ -110,6 +148,7 @@ function GettingStarted() {
   return (
     <div className="comp-page">
       <Navbar />
+      <ScrollProgressBar />
 
       <div className="comp-layout">
         {/* ── Sidebar / table of contents ── */}


### PR DESCRIPTION
## Related Issue
Closes #64

## Changes Made
- Added slim top scroll progress indicator
- Synced progress dynamically with page scroll
- Added smooth animated transitions
- Added dark/light theme support
- Improved reading/navigation experience

## Type of Change
- [x] UI Enhancement

