### PR TITLE
feat: add floating back to top button

### DIFF
--- a/src/components/BackToTop/BackToTop.css
+++ b/src/components/BackToTop/BackToTop.css
@@ -1,0 +1,78 @@
+/* BackToTop.css – Floating "scroll to top" button */
+
+.back-to-top {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(99, 102, 241, 0.35),
+              0 1px 3px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
+              opacity 0.25s ease,
+              box-shadow 0.25s ease;
+
+  /* Hidden by default */
+  opacity: 0;
+  transform: translateY(20px) scale(0.8);
+  pointer-events: none;
+}
+
+.back-to-top--visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.back-to-top:hover {
+  box-shadow: 0 6px 24px rgba(99, 102, 241, 0.5),
+              0 2px 6px rgba(0, 0, 0, 0.12);
+  transform: translateY(-3px) scale(1.08);
+}
+
+.back-to-top:active {
+  transform: translateY(0) scale(0.96);
+  box-shadow: 0 2px 10px rgba(99, 102, 241, 0.3);
+}
+
+/* Focus ring for keyboard navigation */
+.back-to-top:focus-visible {
+  outline: 3px solid rgba(99, 102, 241, 0.5);
+  outline-offset: 3px;
+}
+
+/* ── Dark mode ── */
+[data-theme="dark"] .back-to-top {
+  background: linear-gradient(135deg, #818cf8, #6366f1);
+  box-shadow: 0 4px 20px rgba(129, 140, 248, 0.3),
+              0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .back-to-top:hover {
+  box-shadow: 0 6px 28px rgba(129, 140, 248, 0.5),
+              0 2px 6px rgba(0, 0, 0, 0.25);
+}
+
+/* ── Mobile responsive ── */
+@media (max-width: 768px) {
+  .back-to-top {
+    bottom: 20px;
+    right: 20px;
+    width: 44px;
+    height: 44px;
+  }
+
+  .back-to-top svg {
+    width: 18px;
+    height: 18px;
+  }
+}

--- a/src/components/BackToTop/BackToTop.jsx
+++ b/src/components/BackToTop/BackToTop.jsx
@@ -1,0 +1,63 @@
+// BackToTop.jsx
+// Floating action button that appears after scrolling down ~300px.
+// Smoothly scrolls the page back to the top on click.
+//
+// Props:
+//   threshold (number) – scroll distance in px before button appears (default: 300)
+
+import React, { useState, useEffect } from 'react'
+import './BackToTop.css'
+
+function BackToTop({ threshold = 300 }) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    let ticking = false
+
+    const onScroll = () => {
+      if (!ticking) {
+        requestAnimationFrame(() => {
+          setVisible(window.scrollY > threshold)
+          ticking = false
+        })
+        ticking = true
+      }
+    }
+
+    window.addEventListener('scroll', onScroll, { passive: true })
+    // Check on mount in case the page is already scrolled
+    onScroll()
+
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [threshold])
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return (
+    <button
+      type="button"
+      className={`back-to-top ${visible ? 'back-to-top--visible' : ''}`}
+      onClick={scrollToTop}
+      aria-label="Back to top"
+      id="back-to-top-btn"
+    >
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <polyline points="18 15 12 9 6 15" />
+      </svg>
+    </button>
+  )
+}
+
+export default BackToTop

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -3,6 +3,7 @@ import Button from '../components/Button/Button.jsx'
 import Navbar from '../components/Navbar/Navbar.jsx'
 import Badge from '../components/Badge/Badge.jsx'
 import Alert from '../components/Alert/Alert.jsx'
+import BackToTop from '../components/BackToTop/BackToTop.jsx'
 import { componentsList } from '../data/componentsList.js'
 import './Components.css'
 
@@ -492,6 +493,7 @@ function Components() {
 
         </main>
       </div>
+      <BackToTop />
     </div>
   )
 }

--- a/src/pages/GettingStarted.jsx
+++ b/src/pages/GettingStarted.jsx
@@ -12,6 +12,7 @@ import { Link } from 'react-router-dom'
 import Button from '../components/Button/Button.jsx'
 import Badge from '../components/Badge/Badge.jsx'
 import Navbar from '../components/Navbar/Navbar.jsx'
+import BackToTop from '../components/BackToTop/BackToTop.jsx'
 import './Components.css' // shared layout + code-block + table styles
 import './GettingStarted.css'
 
@@ -451,6 +452,7 @@ export default Card`}
           </section>
         </main>
       </div>
+      <BackToTop />
     </div>
   )
 }


### PR DESCRIPTION
## Related Issue
Closes #65

## Changes Made
- Added floating “Back to Top” button
- Added smooth scroll-to-top animation
- Button appears only after scrolling down
- Responsive across devices
- Added premium gradient/glow UI styling

## Type of Change
- [x] UI Enhancement

