### PR TITLE
feat: add component preview theme switcher

### DIFF
--- a/src/pages/Components.css
+++ b/src/pages/Components.css
@@ -160,9 +160,88 @@
   background-blend-mode: normal;
   border: 1px solid var(--border);
   border-radius: 12px;
+  transition: background 0.35s ease, border-color 0.35s ease;
 }
 
 .comp-preview--align-end { align-items: flex-end; }
+
+/* ── Themed preview wrapper ── */
+.themed-preview-wrap {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  margin-bottom: 24px;
+  transition: border-color 0.35s ease;
+}
+
+/* When inside the wrapper, remove preview's own border + rounded top corners */
+.themed-preview-wrap .comp-preview {
+  border: none;
+  border-radius: 0 0 14px 14px;
+  margin-bottom: 0;
+}
+
+/* Toolbar above the preview */
+.themed-preview-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px 8px 16px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  transition: background 0.35s ease, border-color 0.35s ease;
+}
+
+.themed-preview-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-2);
+  transition: color 0.35s ease;
+}
+
+/* Toggle pill — light/dark radio group */
+.themed-preview-toggle {
+  display: flex;
+  background: var(--surface-2);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 2px;
+  border: 1px solid var(--border);
+  transition: background 0.35s ease, border-color 0.35s ease;
+}
+
+.themed-preview-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 26px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  background: transparent;
+  color: var(--muted-2);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
+}
+
+.themed-preview-btn:hover {
+  color: var(--text);
+  background: var(--accent);
+}
+
+.themed-preview-btn--active {
+  background: var(--brand);
+  color: #fff;
+  box-shadow: 0 1px 4px rgba(79, 70, 229, 0.3);
+}
+
+.themed-preview-btn--active:hover {
+  background: var(--brand-dark);
+  color: #fff;
+}
 
 /* ── Code block ── */
 .code-block {

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -71,6 +71,71 @@ const CheckIcon = () => (
   </svg>
 )
 
+const SunIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="12" cy="12" r="5"/>
+    <line x1="12" y1="1" x2="12" y2="3"/>
+    <line x1="12" y1="21" x2="12" y2="23"/>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+    <line x1="1" y1="12" x2="3" y2="12"/>
+    <line x1="21" y1="12" x2="23" y2="12"/>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+)
+
+const MoonIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+)
+
+/* Themed preview wrapper — scopes theme to just the preview area */
+function ThemedPreview({ children }) {
+  const [previewTheme, setPreviewTheme] = useState(null) // null = follow global
+
+  // Detect current global theme to show the correct initial state
+  const globalTheme = document.documentElement.getAttribute('data-theme') || 'light'
+  const effectiveTheme = previewTheme ?? globalTheme
+
+  return (
+    <div
+      className="themed-preview-wrap"
+      data-theme={previewTheme ?? undefined}
+    >
+      <div className="themed-preview-toolbar">
+        <span className="themed-preview-label">
+          {effectiveTheme === 'dark' ? 'Dark' : 'Light'} Preview
+        </span>
+        <div className="themed-preview-toggle" role="radiogroup" aria-label="Preview theme">
+          <button
+            type="button"
+            className={`themed-preview-btn ${effectiveTheme === 'light' ? 'themed-preview-btn--active' : ''}`}
+            onClick={() => setPreviewTheme('light')}
+            aria-label="Light preview"
+            title="Light theme"
+          >
+            <SunIcon />
+          </button>
+          <button
+            type="button"
+            className={`themed-preview-btn ${effectiveTheme === 'dark' ? 'themed-preview-btn--active' : ''}`}
+            onClick={() => setPreviewTheme('dark')}
+            aria-label="Dark preview"
+            title="Dark theme"
+          >
+            <MoonIcon />
+          </button>
+        </div>
+      </div>
+      <div className="comp-preview">
+        {children}
+      </div>
+    </div>
+  )
+}
+
 /* ================= COMPONENT ================= */
 
 function Components() {
@@ -270,12 +335,12 @@ function Components() {
                 Versatile button component with variants and sizes.
               </p>
 
-              <div className="comp-preview">
+              <ThemedPreview>
                 <Button text="Primary" variant="primary" />
                 <Button text="Secondary" variant="secondary" />
                 <Button text="Danger" variant="danger" />
                 <Button text="Disabled" variant="disabled" />
-              </div>
+              </ThemedPreview>
 
               <div className="code-block">
                 <div className="code-block-header">
@@ -316,12 +381,12 @@ function Components() {
                 Small status indicator badge with color variants.
               </p>
 
-              <div className="comp-preview">
+              <ThemedPreview>
                 <Badge text="Primary" variant="primary" />
                 <Badge text="Success" variant="success" />
                 <Badge text="Warning" variant="warning" />
                 <Badge text="Danger" variant="danger" />
-              </div>
+              </ThemedPreview>
 
               <div className="code-block">
                 <div className="code-block-header">
@@ -367,13 +432,13 @@ function Components() {
               <div className="comp-subsection">
                 <h3 className="comp-subsection-title">Variants</h3>
 
-                <div className="comp-preview">
+                <ThemedPreview>
                   <Alert type="success" message="Action completed successfully!" />
                   <Alert type="error" message="Something went wrong." />
                   <Alert type="warning" message="Warning message here." />
                   <Alert type="info" message="Information message." />
                   <Alert type="info" message="Closable alert example." closable />
-                </div>
+                </ThemedPreview>
               </div>
 
               <div className="code-block">


### PR DESCRIPTION
## Related Issue
Closes #67

## Changes Made
- Added light/dark theme switcher for component preview cards
- Enabled instant preview updates without affecting global theme
- Added smooth transition animations between themes
- Preserved overall application theme compatibility
- Improved component showcase experience for developers

## Type of Change
- [x] New Feature

