### PR TITLE
feat: add recently copied components section

### DIFF
--- a/src/pages/Components.css
+++ b/src/pages/Components.css
@@ -551,3 +551,180 @@
 html {
   scroll-behavior: smooth;
 }
+
+/* ================= ACCESSIBILITY FOCUS STATES ================= */
+.sidebar-item:focus-visible {
+  outline: 3px solid var(--brand);
+  outline-offset: -2px;
+  background: var(--accent);
+}
+
+.clear-search-btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+  background: var(--accent);
+}
+
+.copy-btn:focus-visible {
+  outline: 2px solid #a5b4fc;
+  outline-offset: 2px;
+}
+
+/* ================= RECENTLY COPIED SECTION ================= */
+.recent-section {
+  margin-top: 16px;
+  margin-bottom: 32px;
+  padding: 20px;
+  border-radius: 14px;
+  background: rgba(99, 102, 241, 0.03);
+  border: 1px dashed rgba(99, 102, 241, 0.25);
+  animation: slideInRecent 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes slideInRecent {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.recent-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.recent-title-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.recent-title-group h2 {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--text);
+  margin: 0;
+}
+
+.recent-icon {
+  color: var(--brand);
+}
+
+.clear-all-btn {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 8px;
+  transition: all 0.2s;
+  border: 1px solid transparent;
+}
+
+.clear-all-btn:hover {
+  background: var(--accent);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.clear-all-btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.recent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 12px;
+}
+
+.recent-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+}
+
+.recent-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(99, 102, 241, 0.35);
+  box-shadow: var(--shadow-sm);
+}
+
+.recent-card:focus-visible {
+  outline: 3px solid var(--brand);
+  outline-offset: 2px;
+}
+
+.recent-card-body {
+  padding: 12px 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.recent-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.recent-card-category {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--brand);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.recent-card-name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.recent-card-actions {
+  display: flex;
+  gap: 4px;
+}
+
+.recent-card-action-btn {
+  width: 26px;
+  height: 26px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: var(--accent);
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.2s;
+  padding: 0;
+}
+
+.recent-card-action-btn:hover {
+  color: var(--text);
+  border-color: var(--text-2);
+}
+
+.copy-action-btn:hover {
+  background: rgba(99, 102, 241, 0.1);
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+.remove-action-btn:hover {
+  background: rgba(239, 68, 68, 0.1);
+  border-color: #ef4444;
+  color: #ef4444;
+}
+
+.recent-card-action-btn:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -77,6 +77,15 @@ function Components() {
   const [activeSection, setActiveSection] = useState('buttons')
   const [copied, setCopied] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const [recentlyCopied, setRecentlyCopied] = useState(() => {
+    try {
+      const saved = localStorage.getItem('uiverse_recent_copies')
+      return saved ? JSON.parse(saved) : []
+    } catch (e) {
+      return []
+    }
+  })
+  const [copiedCardId, setCopiedCardId] = useState(null)
   
   // Refs for scrolling
   const buttonsRef = useRef(null)
@@ -84,10 +93,55 @@ function Components() {
   const alertsRef = useRef(null)
   const allComponentsRef = useRef(null)
 
-  const handleCopy = (code) => {
+  const handleCopy = (code, componentId, componentName, category) => {
     navigator.clipboard.writeText(code)
     setCopied(true)
     setTimeout(() => setCopied(false), 1800)
+
+    if (componentId && componentName && category) {
+      setRecentlyCopied((prev) => {
+        const filtered = prev.filter((item) => item.id !== componentId)
+        const updated = [
+          { id: componentId, name: componentName, category, code, timestamp: Date.now() },
+          ...filtered,
+        ].slice(0, 5)
+        localStorage.setItem('uiverse_recent_copies', JSON.stringify(updated))
+        return updated
+      })
+    }
+  }
+
+  const handleQuickCopy = (e, code, componentId) => {
+    e.stopPropagation()
+    navigator.clipboard.writeText(code)
+    setCopiedCardId(componentId)
+    setTimeout(() => setCopiedCardId(null), 1800)
+
+    setRecentlyCopied((prev) => {
+      const target = prev.find((item) => item.id === componentId)
+      if (!target) return prev
+      const filtered = prev.filter((item) => item.id !== componentId)
+      const updated = [
+        { ...target, timestamp: Date.now() },
+        ...filtered,
+      ]
+      localStorage.setItem('uiverse_recent_copies', JSON.stringify(updated))
+      return updated
+    })
+  }
+
+  const removeRecentItem = (e, componentId) => {
+    e.stopPropagation()
+    setRecentlyCopied((prev) => {
+      const updated = prev.filter((item) => item.id !== componentId)
+      localStorage.setItem('uiverse_recent_copies', JSON.stringify(updated))
+      return updated
+    })
+  }
+
+  const clearHistory = () => {
+    setRecentlyCopied([])
+    localStorage.removeItem('uiverse_recent_copies')
   }
 
   const scrollTo = (id) => {
@@ -258,6 +312,78 @@ function Components() {
             </div>
           </div>
 
+          {/* ================= RECENTLY COPIED ================= */}
+          {recentlyCopied.length > 0 && (
+            <section className="recent-section">
+              <div className="recent-header">
+                <div className="recent-title-group">
+                  <svg className="recent-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                    <path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <h2>Recently Copied</h2>
+                </div>
+                <button className="clear-all-btn" onClick={clearHistory} aria-label="Clear all recently copied history">
+                  Clear History
+                </button>
+              </div>
+
+              <div className="recent-grid">
+                {recentlyCopied.map((item) => (
+                  <div
+                    key={item.id}
+                    className="recent-card"
+                    onClick={() => scrollTo(item.id)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        scrollTo(item.id)
+                      }
+                    }}
+                    aria-label={`Recently copied component ${item.name}. Category: ${item.category}. Press Enter to scroll to component section.`}
+                  >
+                    <div className="recent-card-body">
+                      <div className="recent-card-info">
+                        <span className="recent-card-category">{item.category}</span>
+                        <strong className="recent-card-name">{item.name}</strong>
+                      </div>
+                      <div className="recent-card-actions">
+                        <button
+                          className="recent-card-action-btn copy-action-btn"
+                          onClick={(e) => handleQuickCopy(e, item.code, item.id)}
+                          aria-label={`Quick copy JSX snippet for ${item.name}`}
+                          title="Quick Copy JSX"
+                        >
+                          {copiedCardId === item.id ? (
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
+                              <polyline points="20 6 9 17 4 12" />
+                            </svg>
+                          ) : (
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                              <rect x="9" y="9" width="13" height="13" rx="2" />
+                              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+                            </svg>
+                          )}
+                        </button>
+                        <button
+                          className="recent-card-action-btn remove-action-btn"
+                          onClick={(e) => removeRecentItem(e, item.id)}
+                          aria-label={`Remove ${item.name} from recently copied history`}
+                          title="Remove from history"
+                        >
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                            <line x1="18" y1="6" x2="6" y2="18" />
+                            <line x1="6" y1="6" x2="18" y2="18" />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
           {/* ================= BUTTONS ================= */}
           {shouldShowSection('buttons', 'Button') && (
             <section className="comp-section" id="buttons" ref={buttonsRef}>
@@ -284,7 +410,7 @@ function Components() {
                   <button
                     className="copy-btn"
                     onClick={() =>
-                      handleCopy(`<Button text="Primary" variant="primary" />`)
+                      handleCopy(`<Button text="Primary" variant="primary" />`, 'buttons', 'Button', 'Inputs')
                     }
                   >
                     {copied ? (
@@ -330,7 +456,7 @@ function Components() {
                   <button
                     className="copy-btn"
                     onClick={() =>
-                      handleCopy(`<Badge text="Primary" variant="primary" />`)
+                      handleCopy(`<Badge text="Primary" variant="primary" />`, 'badges', 'Badge', 'Display')
                     }
                   >
                     {copied ? (
@@ -386,7 +512,7 @@ function Components() {
 <Alert type="error" message="Something went wrong." />
 <Alert type="warning" message="Warning message here." />
 <Alert type="info" message="Information message." />
-<Alert type="info" message="Closable alert example." closable />`)
+<Alert type="info" message="Closable alert example." closable />`, 'alerts', 'Alert', 'Feedback')
                     }
                   >
                     {copied ? '✅ Copied!' : '📋 Copy'}


### PR DESCRIPTION
## Related Issue
Closes #69

## Changes Made
- Added “Recently Copied Components” section
- Tracked copied components using localStorage
- Added quick revisit functionality
- Added clear history option
- Improved developer workflow and usability

## Type of Change
- [x] New Feature

