### PR TITLE
refactor: dynamic showcase rendering & route-level code splitting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,27 @@
 // App.jsx – Root component that defines all routes
 // To add a new page: import it and add a new <Route> below
 
-import React from 'react'
+import React, { Suspense, lazy } from 'react'
 import { Routes, Route } from 'react-router-dom'
-import Home from './pages/Home.jsx'
-import Components from './pages/Components.jsx'
-import GettingStarted from './pages/GettingStarted.jsx'
+
+const Home = lazy(() => import('./pages/Home.jsx'))
+const Components = lazy(() => import('./pages/Components.jsx'))
+const GettingStarted = lazy(() => import('./pages/GettingStarted.jsx'))
 
 function App() {
   return (
-    <Routes>
-      {/* Home page – landing screen */}
-      <Route path="/" element={<Home />} />
+    <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center' }}>Loading...</div>}>
+      <Routes>
+        {/* Home page – landing screen */}
+        <Route path="/" element={<Home />} />
 
-      {/* Components showcase page */}
-      <Route path="/components" element={<Components />} />
+        {/* Components showcase page */}
+        <Route path="/components" element={<Components />} />
 
-      {/* Getting Started / documentation page */}
-      <Route path="/docs" element={<GettingStarted />} />
-    </Routes>
+        {/* Getting Started / documentation page */}
+        <Route path="/docs" element={<GettingStarted />} />
+      </Routes>
+    </Suspense>
   )
 }
 

--- a/src/data/componentsList.js
+++ b/src/data/componentsList.js
@@ -1,13 +1,9 @@
-// componentsList.js – Metadata registry for all UIverse components
-//
-// Each entry describes one component available in the library.
-// This data is used by the Components page to render the overview table.
-//
-// To register a new component:
-//   1. Add a new object to the array below
-//   2. Fill in: id, name, category, status, description
-//   3. Status options: "Stable" | "Beta" | "Planned" 
+import React from 'react'
+import Button from '../components/Button/Button.jsx'
+import Badge from '../components/Badge/Badge.jsx'
+import Alert from '../components/Alert/Alert.jsx'
 
+// componentsList.js – Metadata registry for all UIverse components
 export const componentsList = [
   {
     id: 1,
@@ -15,6 +11,15 @@ export const componentsList = [
     category: 'Inputs',
     status: 'Stable',
     description: 'Reusable button with primary, secondary, and danger variants.',
+    preview: (
+      <>
+        <Button text="Primary" variant="primary" />
+        <Button text="Secondary" variant="secondary" />
+        <Button text="Danger" variant="danger" />
+        <Button text="Disabled" variant="disabled" />
+      </>
+    ),
+    code: `<Button text="Primary" variant="primary" />`
   },
   {
     id: 2,
@@ -43,6 +48,15 @@ export const componentsList = [
     category: 'Display',
     status: 'Stable',
     description: 'Small status indicator badge with color variants.',
+    preview: (
+      <>
+        <Badge text="Primary" variant="primary" />
+        <Badge text="Success" variant="success" />
+        <Badge text="Warning" variant="warning" />
+        <Badge text="Danger" variant="danger" />
+      </>
+    ),
+    code: `<Badge text="Primary" variant="primary" />`
   },
   {
     id: 6,
@@ -51,15 +65,25 @@ export const componentsList = [
     status: 'Planned',
     description: 'Responsive top navigation bar with logo and links.',
   },
-
-
-  // New Alert component
   {
     id: 7,
     name: 'Alert',
     category: 'Feedback',
     status: 'Stable',
-    description:
-      'Reusable alert component for success, error, warning, and informational messages.',
+    description: 'Reusable alert component for success, error, warning, and informational messages.',
+    preview: (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '100%' }}>
+        <Alert type="success" message="Action completed successfully!" />
+        <Alert type="error" message="Something went wrong." />
+        <Alert type="warning" message="Warning message here." />
+        <Alert type="info" message="Information message." />
+        <Alert type="info" message="Closable alert example." closable />
+      </div>
+    ),
+    code: `<Alert type="success" message="Action completed successfully!" />
+<Alert type="error" message="Something went wrong." />
+<Alert type="warning" message="Warning message here." />
+<Alert type="info" message="Information message." />
+<Alert type="info" message="Closable alert example." closable />`
   },
 ]

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -1,60 +1,7 @@
 import React, { useState, useMemo, useEffect, useRef } from 'react'
-import Button from '../components/Button/Button.jsx'
 import Navbar from '../components/Navbar/Navbar.jsx'
-import Badge from '../components/Badge/Badge.jsx'
-import Alert from '../components/Alert/Alert.jsx'
 import { componentsList } from '../data/componentsList.js'
 import './Components.css'
-
-/* ================= SECTIONS ================= */
-
-const sections = [
-  {
-    id: 'buttons',
-    label: 'Buttons',
-    componentName: 'Button',
-    icon: (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <rect x="3" y="8" width="18" height="8" rx="3"/>
-      </svg>
-    ),
-  },
-  {
-    id: 'badges',
-    label: 'Badges',
-    componentName: 'Badge',
-    icon: (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M12 2l4 7h7l-5.5 4.5L19 21l-7-4-7 4 1.5-7.5L1 9h7z"/>
-      </svg>
-    ),
-  },
-  {
-    id: 'alerts',
-    label: 'Alerts',
-    componentName: 'Alert',
-    icon: (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M10 2L2 22h20L14 2z"/>
-      </svg>
-    ),
-  },
-  {
-    id: 'all-components',
-    label: 'All Components',
-    componentName: null,
-    icon: (
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <line x1="8" y1="6" x2="21" y2="6"/>
-        <line x1="8" y1="12" x2="21" y2="12"/>
-        <line x1="8" y1="18" x2="21" y2="18"/>
-        <line x1="3" y1="6" x2="3.01" y2="6"/>
-        <line x1="3" y1="12" x2="3.01" y2="12"/>
-        <line x1="3" y1="18" x2="3.01" y2="18"/>
-      </svg>
-    ),
-  },
-]
 
 /* ================= ICONS ================= */
 
@@ -71,46 +18,60 @@ const CheckIcon = () => (
   </svg>
 )
 
+const GenericIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <rect x="3" y="8" width="18" height="8" rx="3"/>
+  </svg>
+)
+
+const AllIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <line x1="8" y1="6" x2="21" y2="6"/>
+    <line x1="8" y1="12" x2="21" y2="12"/>
+    <line x1="8" y1="18" x2="21" y2="18"/>
+    <line x1="3" y1="6" x2="3.01" y2="6"/>
+    <line x1="3" y1="12" x2="3.01" y2="12"/>
+    <line x1="3" y1="18" x2="3.01" y2="18"/>
+  </svg>
+)
+
 /* ================= COMPONENT ================= */
 
 function Components() {
-  const [activeSection, setActiveSection] = useState('buttons')
-  const [copied, setCopied] = useState(false)
+  // Generate sections dynamically from componentsList
+  const dynamicSections = useMemo(() => {
+    const stableComponents = componentsList.filter(c => c.status === 'Stable')
+    const sections = stableComponents.map(c => ({
+      id: c.name.toLowerCase() + 's',
+      label: c.name + 's',
+      componentName: c.name,
+      icon: <GenericIcon />,
+    }))
+    sections.push({
+      id: 'all-components',
+      label: 'All Components',
+      componentName: null,
+      icon: <AllIcon />,
+    })
+    return sections
+  }, [])
+
+  const [activeSection, setActiveSection] = useState(dynamicSections[0]?.id || 'all-components')
+  const [copiedCode, setCopiedCode] = useState(null)
   const [searchQuery, setSearchQuery] = useState('')
   
   // Refs for scrolling
-  const buttonsRef = useRef(null)
-  const badgesRef = useRef(null)
-  const alertsRef = useRef(null)
-  const allComponentsRef = useRef(null)
+  const sectionRefs = useRef({})
 
-  const handleCopy = (code) => {
+  const handleCopy = (code, id) => {
     navigator.clipboard.writeText(code)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1800)
+    setCopiedCode(id)
+    setTimeout(() => setCopiedCode(null), 1800)
   }
 
   const scrollTo = (id) => {
     setActiveSection(id)
-    let element = null
-    
-    switch(id) {
-      case 'buttons':
-        element = buttonsRef.current
-        break
-      case 'badges':
-        element = badgesRef.current
-        break
-      case 'alerts':
-        element = alertsRef.current
-        break
-      case 'all-components':
-        element = allComponentsRef.current
-        break
-      default:
-        element = document.getElementById(id)
-    }
-    
+    const element = sectionRefs.current[id]
     if (element) {
       element.scrollIntoView({
         behavior: 'smooth',
@@ -136,60 +97,44 @@ function Components() {
     
     const searchLower = searchQuery.toLowerCase()
     
-    // Check if component name matches search
     if (componentName && componentName.toLowerCase().includes(searchLower)) {
       return true
     }
     
-    // Check if any component in filtered list matches this section
     return filteredComponents.some(c => c.name === componentName)
   }
 
-  // Auto-scroll to first matching section when searching
   useEffect(() => {
     if (searchQuery.trim()) {
-      const searchLower = searchQuery.toLowerCase()
-      
-      // Find first matching section
-      if (searchLower.includes('button') || filteredComponents.some(c => c.name === 'Button')) {
-        scrollTo('buttons')
-      } else if (searchLower.includes('badge') || filteredComponents.some(c => c.name === 'Badge')) {
-        scrollTo('badges')
-      } else if (searchLower.includes('alert') || filteredComponents.some(c => c.name === 'Alert')) {
-        scrollTo('alerts')
-      } else if (filteredComponents.length > 0) {
-        scrollTo('all-components')
+      const firstMatching = dynamicSections.find(s => 
+        s.componentName ? shouldShowSection(s.id, s.componentName) : filteredComponents.length > 0
+      )
+      if (firstMatching) {
+        scrollTo(firstMatching.id)
       }
     }
   }, [searchQuery])
 
-  // Clear search function
   const clearSearch = () => {
     setSearchQuery('')
   }
 
-  // Get visible sections count
   const visibleSectionsCount = useMemo(() => {
-    let count = 0
-    if (shouldShowSection('buttons', 'Button')) count++
-    if (shouldShowSection('badges', 'Badge')) count++
-    if (shouldShowSection('alerts', 'Alert')) count++
-    if (filteredComponents.length > 0) count++
-    return count
-  }, [searchQuery, filteredComponents])
+    return dynamicSections.filter(s => 
+      s.componentName ? shouldShowSection(s.id, s.componentName) : filteredComponents.length > 0
+    ).length
+  }, [searchQuery, filteredComponents, dynamicSections])
 
   return (
     <div className="comp-page">
       <Navbar />
 
       <div className="comp-layout">
-
         {/* ================= SIDEBAR ================= */}
         <aside className="comp-sidebar">
           <p className="sidebar-label">ON THIS PAGE</p>
 
-          {sections.map((s) => {
-            // Only show section in sidebar if it has content when searching
+          {dynamicSections.map((s) => {
             if (searchQuery.trim()) {
               if (s.id === 'all-components' && filteredComponents.length === 0) return null
               if (s.componentName && !shouldShowSection(s.id, s.componentName)) return null
@@ -208,9 +153,7 @@ function Components() {
           })}
 
           <div className="sidebar-divider" />
-
           <p className="sidebar-label">CONTRIBUTE</p>
-
           <a
             href="https://github.com/ayushkashyap402/UIverse"
             target="_blank"
@@ -228,7 +171,6 @@ function Components() {
 
         {/* ================= MAIN ================= */}
         <main className="comp-main">
-
           <div className="comp-header">
             <h1>Components</h1>
             <p>Production-ready UI components. Copy the code, drop it in, done.</p>
@@ -258,188 +200,60 @@ function Components() {
             </div>
           </div>
 
-          {/* ================= BUTTONS ================= */}
-          {shouldShowSection('buttons', 'Button') && (
-            <section className="comp-section" id="buttons" ref={buttonsRef}>
-              <div className="comp-section-header">
-                <h2>Button</h2>
-                <span className="comp-badge comp-badge--stable">Stable</span>
-              </div>
+          {/* DYNAMIC SECTIONS */}
+          {componentsList.filter(c => c.status === 'Stable').map(c => {
+            const sectionId = c.name.toLowerCase() + 's'
+            if (!shouldShowSection(sectionId, c.name)) return null
 
-              <p className="comp-section-desc">
-                Versatile button component with variants and sizes.
-              </p>
-
-              <div className="comp-preview">
-                <Button text="Primary" variant="primary" />
-                <Button text="Secondary" variant="secondary" />
-                <Button text="Danger" variant="danger" />
-                <Button text="Disabled" variant="disabled" />
-              </div>
-
-              <div className="code-block">
-                <div className="code-block-header">
-                  <span>JSX</span>
-
-                  <button
-                    className="copy-btn"
-                    onClick={() =>
-                      handleCopy(`<Button text="Primary" variant="primary" />`)
-                    }
-                  >
-                    {copied ? (
-                      <>
-                        <CheckIcon /> Copied
-                      </>
-                    ) : (
-                      <>
-                        <CopyIcon /> Copy
-                      </>
-                    )}
-                  </button>
+            return (
+              <section 
+                key={c.id} 
+                className="comp-section" 
+                id={sectionId} 
+                ref={el => sectionRefs.current[sectionId] = el}
+              >
+                <div className="comp-section-header">
+                  <h2>{c.name}</h2>
+                  <span className="comp-badge comp-badge--stable">Stable</span>
                 </div>
 
-                <pre>{`<Button text="Primary" variant="primary" />`}</pre>
-              </div>
-            </section>
-          )}
+                <p className="comp-section-desc">{c.description}</p>
 
-          {/* ================= BADGES ================= */}
-          {shouldShowSection('badges', 'Badge') && (
-            <section className="comp-section" id="badges" ref={badgesRef}>
-              <div className="comp-section-header">
-                <h2>Badge</h2>
-                <span className="comp-badge comp-badge--stable">Stable</span>
-              </div>
+                {c.preview && (
+                  <div className="comp-preview">
+                    {c.preview}
+                  </div>
+                )}
 
-              <p className="comp-section-desc">
-                Small status indicator badge with color variants.
-              </p>
-
-              <div className="comp-preview">
-                <Badge text="Primary" variant="primary" />
-                <Badge text="Success" variant="success" />
-                <Badge text="Warning" variant="warning" />
-                <Badge text="Danger" variant="danger" />
-              </div>
-
-              <div className="code-block">
-                <div className="code-block-header">
-                  <span>JSX</span>
-
-                  <button
-                    className="copy-btn"
-                    onClick={() =>
-                      handleCopy(`<Badge text="Primary" variant="primary" />`)
-                    }
-                  >
-                    {copied ? (
-                      <>
-                        <CheckIcon /> Copied
-                      </>
-                    ) : (
-                      <>
-                        <CopyIcon /> Copy
-                      </>
-                    )}
-                  </button>
-                </div>
-
-                <pre>{`<Badge text="Primary" variant="primary" />`}</pre>
-              </div>
-            </section>
-          )}
-
-          {/* ================= ALERTS ================= */}
-          {shouldShowSection('alerts', 'Alert') && (
-            <section className="comp-section" id="alerts" ref={alertsRef}>
-              <div className="comp-section-header">
-                <h2>Alert</h2>
-                <span className="comp-badge comp-badge--stable">Stable</span>
-              </div>
-
-              <p className="comp-section-desc">
-                Reusable alert component with multiple variants
-                for success, error, warning, and informational
-                messages.
-              </p>
-
-              <div className="comp-subsection">
-                <h3 className="comp-subsection-title">Variants</h3>
-
-                <div className="comp-preview">
-                  <Alert type="success" message="Action completed successfully!" />
-                  <Alert type="error" message="Something went wrong." />
-                  <Alert type="warning" message="Warning message here." />
-                  <Alert type="info" message="Information message." />
-                  <Alert type="info" message="Closable alert example." closable />
-                </div>
-              </div>
-
-              <div className="code-block">
-                <div className="code-block-header">
-                  <span>JSX</span>
-                  <button
-                    className="copy-btn"
-                    onClick={() =>
-                      handleCopy(`<Alert type="success" message="Action completed successfully!" />
-<Alert type="error" message="Something went wrong." />
-<Alert type="warning" message="Warning message here." />
-<Alert type="info" message="Information message." />
-<Alert type="info" message="Closable alert example." closable />`)
-                    }
-                  >
-                    {copied ? '✅ Copied!' : '📋 Copy'}
-                  </button>
-                </div>
-                <pre>{`<Alert type="success" message="Action completed successfully!" />
-<Alert type="error" message="Something went wrong." />
-<Alert type="warning" message="Warning message here." />
-<Alert type="info" message="Information message." />
-<Alert type="info" message="Closable alert example." closable />`}</pre>
-              </div>
-
-              <div className="comp-subsection">
-                <h3 className="comp-subsection-title">Props</h3>
-                <div className="props-table-wrap">
-                  <table className="props-table">
-                    <thead>
-                      <tr>
-                        <th>Prop</th>
-                        <th>Type</th>
-                        <th>Default</th>
-                        <th>Description</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td><code>type</code></td>
-                        <td>string</td>
-                        <td><code>"info"</code></td>
-                        <td>success · error · warning · info</td>
-                      </tr>
-                      <tr>
-                        <td><code>message</code></td>
-                        <td>string</td>
-                        <td><code>"This is an alert"</code></td>
-                        <td>Alert message text</td>
-                      </tr>
-                      <tr>
-                        <td><code>closable</code></td>
-                        <td>boolean</td>
-                        <td><code>false</code></td>
-                        <td>Shows close button</td>
-                      </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-            </section>
-          )}
+                {c.code && (
+                  <div className="code-block">
+                    <div className="code-block-header">
+                      <span>JSX</span>
+                      <button
+                        className="copy-btn"
+                        onClick={() => handleCopy(c.code, c.id)}
+                      >
+                        {copiedCode === c.id ? (
+                          <><CheckIcon /> Copied</>
+                        ) : (
+                          <><CopyIcon /> Copy</>
+                        )}
+                      </button>
+                    </div>
+                    <pre>{c.code}</pre>
+                  </div>
+                )}
+              </section>
+            )
+          })}
 
           {/* ================= ALL COMPONENTS TABLE ================= */}
           {filteredComponents.length > 0 && (
-            <section className="comp-section" id="all-components" ref={allComponentsRef}>
+            <section 
+              className="comp-section" 
+              id="all-components" 
+              ref={el => sectionRefs.current['all-components'] = el}
+            >
               <div className="comp-section-header">
                 <h2>All Components</h2>
                 {searchQuery && (
@@ -486,7 +300,6 @@ function Components() {
                 <line x1="21" y1="21" x2="16.65" y2="16.65"/>
               </svg>
               <p>🔍 No components found matching <strong>"{searchQuery}"</strong></p>
-              <p>Try searching for "Button", "Alert", "Badge", or a category like "Inputs" or "Feedback"</p>
             </div>
           )}
 


### PR DESCRIPTION
## Description

This PR refactors the showcase architecture to support dynamic rendering and implements route-level code splitting.

Closes #115 

### Changes Made

- **Route Code-Splitting:** Wrapped the main routes in `App.jsx` with `React.lazy()` and `Suspense`. This ensures that the landing page (`Home`) does not unnecessarily download all the UI components on the initial load, improving the Lighthouse performance score.
- **Dynamic Component Showcase:** 
  - Extensively refactored `Components.jsx`. Instead of hardcoding HTML/JSX sections for every new component, the page now automatically generates the sidebar navigation and component preview blocks by mapping over `componentsList.js`.
  - Enriched `componentsList.js` to store the actual component preview JSX and the copyable code snippets.
  - Adding a new component to the showcase is now a 2-step process instead of a 3-step process.

### Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor / Performance Improvement
- [ ] Breaking change

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] The `Components` page renders properly and the search filter continues to work
