### PR TITLE
feat: add category filter buttons to Components page

### DIFF
--- a/src/pages/Components.css
+++ b/src/pages/Components.css
@@ -613,10 +613,6 @@
   }
 }
 
-
-
-/* Add these styles to Components.css */
-
 .filtered-badge {
   display: inline-flex;
   align-items: center;
@@ -672,4 +668,48 @@
 /* Smooth scrolling for the whole page */
 html {
   scroll-behavior: smooth;
+}
+
+/* ── Category Filter Buttons ── */
+.category-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.category-filter-btn {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s ease;
+}
+
+.category-filter-btn:hover {
+  border-color: var(--brand);
+  color: var(--brand);
+}
+
+.category-filter-btn--active {
+  background: var(--brand);
+  color: white;
+  border-color: var(--brand);
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
+  .category-filters {
+    gap: 6px;
+  }
+
+  .category-filter-btn {
+    padding: 5px 11px;
+    font-size: 0.78rem;
+  }
 }

--- a/src/pages/Components.jsx
+++ b/src/pages/Components.jsx
@@ -90,6 +90,7 @@ function Components() {
   const [activeSection, setActiveSection] = useState('buttons')
   const [copied, setCopied] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
+  const [activeCategory, setActiveCategory] = useState('All')
   // Mobile sidebar drawer state
   const [sidebarOpen, setSidebarOpen] = useState(false)
   
@@ -140,27 +141,34 @@ function Components() {
 
   // Filter components based on search
   const filteredComponents = useMemo(() => {
-    if (!searchQuery.trim()) return componentsList
-    
-    const searchLower = searchQuery.toLowerCase()
-    return componentsList.filter(component => 
-      component.name.toLowerCase().includes(searchLower) ||
-      component.category.toLowerCase().includes(searchLower)
-    )
-  }, [searchQuery])
+    return componentsList.filter(component => {
+      const matchesSearch = !searchQuery.trim() ||
+        component.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        component.category.toLowerCase().includes(searchQuery.toLowerCase())
 
-  // Check if a section should be shown based on search
+      const matchesCategory = activeCategory === 'All' ||
+        component.category === activeCategory
+
+      return matchesSearch && matchesCategory
+    })
+  }, [searchQuery, activeCategory])
+
+  // Check if a section should be shown based on search and category
   const shouldShowSection = (sectionId, componentName) => {
-    if (!searchQuery.trim()) return true
-    
-    const searchLower = searchQuery.toLowerCase()
-    
-    // Check if component name matches search
-    if (componentName && componentName.toLowerCase().includes(searchLower)) {
-      return true
+    if (!componentName) return true
+
+    // Check category filter first
+    if (activeCategory !== 'All') {
+      const componentInCategory = filteredComponents.some(c => c.name === componentName)
+      if (!componentInCategory) return false
     }
-    
-    // Check if any component in filtered list matches this section
+
+    // Then check search
+    if (!searchQuery.trim()) return true
+
+    const searchLower = searchQuery.toLowerCase()
+    if (componentName.toLowerCase().includes(searchLower)) return true
+
     return filteredComponents.some(c => c.name === componentName)
   }
 
@@ -294,13 +302,27 @@ function Components() {
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="search-input"
-                />
+                  />
                 {searchQuery && (
-                  <button onClick={clearSearch} className="clear-search-btn" aria-label="Clear search">
+                  <button on Click={clearSearch} className="clear-search-btn" aria-label="Clear search">
                     ✕
                   </button>
-                )}
+                  )}
               </div>
+
+              {/* CATEGORY FILTER BUTTONS */}
+              <div className="category-filters">
+              {['All', 'Inputs', 'Layout', 'Overlay', 'Display', 'Navigation', 'Feedback'].map(cat => (
+                  <button
+                    key={cat}
+                    className={`category-filter-btn ${activeCategory === cat ? 'category-filter-btn--active' : ''}`}
+                    onClick={() => setActiveCategory(cat)}
+                  >
+                    {cat}
+                  </button>
+                ))}
+              </div>
+
               {searchQuery && (
                 <p className="search-results-info">
                   Found {filteredComponents.length} component{filteredComponents.length !== 1 ? 's' : ''} matching "{searchQuery}"
@@ -309,7 +331,6 @@ function Components() {
               )}
             </div>
           </div>
-
           {/* ================= BUTTONS ================= */}
           {shouldShowSection('buttons', 'Button') && (
             <section className="comp-section" id="buttons" ref={buttonsRef}>
@@ -687,7 +708,7 @@ function Components() {
           )}
 
           {/* NO RESULTS MESSAGE */}
-          {searchQuery && filteredComponents.length === 0 && (
+          {(searchQuery || activeCategory !== 'All') && filteredComponents.length === 0 && (
             <div className="no-results">
               <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
                 <circle cx="11" cy="11" r="8"/>


### PR DESCRIPTION
## What does this PR do?
Adds category filter buttons to the Components page so users can filter components by category (Inputs, Layout, Overlay, Display, Navigation, Feedback).

## Changes made
- Added `activeCategory` state in `Components.jsx`
- Updated `filteredComponents` logic to filter by both search query and category
- Updated `shouldShowSection` to hide sections not matching the selected category
- Added category filter buttons JSX below the search bar
- Added CSS styles for `.category-filters` and `.category-filter-btn` in `Components.css`

## How to test
1. Go to `/components` page
2. Click any category button e.g. **Inputs** — only Button section shows
3. Click **Display** — only Badge section shows
4. Click **All** — everything comes back
5. Combine with search — both filters work together

Closes #59

<img width="1866" height="892" alt="Screenshot 2026-06-23 221249" src="https://github.com/user-attachments/assets/d9f2f904-8c62-4899-84f9-9508cecb7655" />
<img width="1905" height="901" alt="Screenshot 2026-06-23 221230" src="https://github.com/user-attachments/assets/6b357e5f-2f46-4b71-82d3-beec8ad20a99" />
<img width="1860" height="877" alt="Screenshot 2026-06-23 221214" src="https://github.com/user-attachments/assets/2a5e9274-0f81-4bbf-bd0a-b577cf3df9f0" />
<img width="1043" height="242" alt="Screenshot 2026-06-23 221146" src="https://github.com/user-attachments/assets/96bc935b-8da3-4caf-9fdc-25c6af8143e5" />
